### PR TITLE
Scenario execution history - Missing subscribe on list replay button

### DIFF
--- a/chutney/ui/src/app/modules/scenarios/components/execution/history/scenario-executions-history.component.html
+++ b/chutney/ui/src/app/modules/scenarios/components/execution/history/scenario-executions-history.component.html
@@ -29,7 +29,7 @@
           <chutney-scenario-executions [executions]="executions" [scenario]="scenario"
             [(filters)]="executionsFilters"
           (onExecutionSelect)="openReport($event)"
-          (onReplay)="replay($event)"
+          (onReplay)="replayButton($event)"
           (onDelete)="deleteExecution($event)"></chutney-scenario-executions>
         </ng-template>
       </li>

--- a/chutney/ui/src/app/modules/scenarios/components/execution/history/scenario-executions-history.component.ts
+++ b/chutney/ui/src/app/modules/scenarios/components/execution/history/scenario-executions-history.component.ts
@@ -280,7 +280,7 @@ export class ScenarioExecutionsHistoryComponent implements OnInit, OnDestroy {
                     this.error = error.error;
                     return throwError(() => error);
                 })
-            )   
+            )
     }
 
     ngOnDestroy(): void {
@@ -290,6 +290,10 @@ export class ScenarioExecutionsHistoryComponent implements OnInit, OnDestroy {
 
     getActiveTab() {
         return this.activeTab === this.LAST_ID ? this.executions[0]?.executionId?.toString() : this.activeTab;
+    }
+
+    replayButton(executionId: number) {
+        this.replay(executionId).subscribe();
     }
 
     replay(executionId: number): Observable<any> {


### PR DESCRIPTION
Fix for commit https://github.com/Enedis-OSS/chutney/commit/5d39b3bbb6c6057aae7dc8e25760a65292d9302a which introduced the non subscription of the observable returned by the function replay() in _scenario-execution-history.ts_ used in associated HTML template.