### PR TITLE
Scenario execution - SSE Autorization header

### DIFF
--- a/chutney/packaging/local-api-unsecure/src/main/java/com/chutneytesting/SecurityConfiguration.java
+++ b/chutney/packaging/local-api-unsecure/src/main/java/com/chutneytesting/SecurityConfiguration.java
@@ -43,6 +43,7 @@ public class SecurityConfiguration {
 
     private UserDto getDefaultUser() {
         UserDto defaultUser = new UserDto();
+        defaultUser.setId("plugin");
         defaultUser.setName("ChutneyPluginUser");
         defaultUser.addRole("ADMIN");
         Arrays.stream(Authorization.values()).map(Enum::name).forEach(defaultUser::grantAuthority);

--- a/chutney/ui/src/app/core/services/scenario-execution.service.ts
+++ b/chutney/ui/src/app/core/services/scenario-execution.service.ts
@@ -22,11 +22,8 @@ import { parse } from 'lossless-json'
 export class ScenarioExecutionService {
 
     resourceUrl = '/api/ui/scenario';
-    token: string;
 
-    constructor(private http: HttpClient) {
-        this.token = localStorage.getItem('jwt') || sessionStorage.getItem('access_token');
-    }
+    constructor(private http: HttpClient) {}
 
     findScenarioExecutions(scenarioId: string): Observable<Execution[]> {
         return this.http.get<Execution[]>(environment.backend + `${this.resourceUrl}/${scenarioId}/execution/v1`)
@@ -89,9 +86,10 @@ export class ScenarioExecutionService {
         return new Observable<ScenarioExecutionReport>(obs => {
             let es;
             try {
+                const token = localStorage.getItem('jwt') || sessionStorage.getItem('access_token');
                 es = new EventSourcePolyfill(url, {
                     headers: {
-                        Authorization: `Bearer ${this.token}`
+                        Authorization: `Bearer ${token}`
                     }
                 });
                 es.onerror = () => obs.error('Error loading execution');

--- a/chutney/ui/src/app/core/services/scenario-execution.service.ts
+++ b/chutney/ui/src/app/core/services/scenario-execution.service.ts
@@ -87,11 +87,15 @@ export class ScenarioExecutionService {
             let es;
             try {
                 const token = localStorage.getItem('jwt') || sessionStorage.getItem('access_token');
-                es = new EventSourcePolyfill(url, {
-                    headers: {
-                        Authorization: `Bearer ${token}`
-                    }
-                });
+                var sseHeaders = {};
+                if (token && token.length > 0) {
+                    sseHeaders = {
+                        headers: {
+                            Authorization: `Bearer ${token}`
+                        }
+                    };
+                }
+                es = new EventSourcePolyfill(url, sseHeaders);
                 es.onerror = () => obs.error('Error loading execution');
                 es.addEventListener('partial', (evt: any) => {
                     obs.next(this.buildExecutionReportFromEvent(JSON.parse(evt.data)));


### PR DESCRIPTION
#### Describe the changes you've made

To fix scenario execution Server Side Event HTTP `401` response  :
* Read storage for each construction of the sse observable
* No `Autorization` header when no token

Bonus :
* Set id on `local-api-unsecure` for default user (allow to execute scenario via ui)

#### Checklist

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
