### PR TITLE
fix(ui): close execution modal on scenarios exec page exit

### DIFF
--- a/chutney/ui/src/app/modules/scenarios/components/execution/sub/right-side-bar/scenario-execution-menu.component.ts
+++ b/chutney/ui/src/app/modules/scenarios/components/execution/sub/right-side-bar/scenario-execution-menu.component.ts
@@ -10,7 +10,7 @@ import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, Template
 import { Authorization, ScenarioIndex, TestCase } from '@model';
 import { JiraPluginService, LoginService, ScenarioService } from '@core/services';
 import { ActivatedRoute, Router } from '@angular/router';
-import { combineLatestWith, forkJoin, Observable, of, Subject, switchMap, takeUntil, tap } from 'rxjs';
+import { forkJoin, Observable, of, Subject, switchMap, takeUntil, tap } from 'rxjs';
 import { FileSaverService } from 'ngx-filesaver';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
@@ -18,7 +18,7 @@ import { EventManagerService } from '@shared';
 import { MenuItem } from '@shared/components/layout/menuItem';
 import { EnvironmentService } from '@core/services/environment.service';
 import { ScenarioExecuteModalComponent } from '@shared/components/execute-modal/scenario-execute-modal.component';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
     selector: 'chutney-scenario-execution-menu',
@@ -49,6 +49,7 @@ export class ScenarioExecutionMenuComponent implements OnInit, OnChanges, OnDest
         iconClass: 'fa fa-play',
         authorizations: [Authorization.SCENARIO_EXECUTE]
     };
+    private executionModal: NgbModalRef;
 
     constructor(private environmentService: EnvironmentService,
         private fileSaverService: FileSaverService,
@@ -89,6 +90,7 @@ export class ScenarioExecutionMenuComponent implements OnInit, OnChanges, OnDest
     ngOnDestroy() {
         this.unsubscribeSub$.next();
         this.unsubscribeSub$.complete();
+        this.executionModal && this.executionModal.close();
     }
 
     private addReplayButtonIfNecessary() {
@@ -105,15 +107,9 @@ export class ScenarioExecutionMenuComponent implements OnInit, OnChanges, OnDest
         const executeCallback = (env: string, dataset: string) => {
             this.eventManagerService.broadcast({ name: 'execute', env: env, dataset: dataset});
         }
-        let modalSize: "lg" | "xl" = "lg"
-        const changeModalSize = (size: "lg" | "xl") => {
-            modalSize = size;
-            modalRef.update({size: modalSize})
-        }
-        const modalRef = this.ngbModalService.open(ScenarioExecuteModalComponent, { centered: true, size: modalSize });
-        modalRef.componentInstance.environments = this.environments;
-        modalRef.componentInstance.executeCallback = executeCallback;
-        modalRef.componentInstance.changeModalSize = changeModalSize;
+        this.executionModal = this.ngbModalService.open(ScenarioExecuteModalComponent, { centered: true, size: 'lg' });
+        this.executionModal.componentInstance.environments = this.environments;
+        this.executionModal.componentInstance.executeCallback = executeCallback;
     }
 
     deleteScenario(id: string) {


### PR DESCRIPTION
<!--
  ~ SPDX-FileCopyrightText: 2017-2024 Enedis
  ~
  ~ SPDX-License-Identifier: Apache-2.0
  ~
  -->

#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made
Close execution modal when leaving scenarios executions page.
<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [ ] All new and existing tests pass
- [ ] No git conflict
