### PR TITLE
Fix tasks inputs/outputs pretty print on exec report

### DIFF
--- a/chutney/ui/src/app/modules/scenarios/components/execution/detail/execution.component.html
+++ b/chutney/ui/src/app/modules/scenarios/components/execution/detail/execution.component.html
@@ -326,7 +326,7 @@
                     <i class="fa-sm fa-regular fa-copy"></i>
                   </span>
                                     @if (enableEditorView(input)) {
-                                        <span title="{{'scenarios.execution.step.actions.edit' | translate}}"
+                                        <span title="{{'scenarios.execution.step.actions.view' | translate}}"
                                               class="ms-3 action" (click)="openOffCanva(monaco, input.value)">
                       <i class="fa-sm fa-regular fa-eye"></i>
                     </span>
@@ -374,7 +374,7 @@
                   <i class="fa-sm fa-regular fa-copy"></i>
                 </span>
                                 @if (enableEditorView(output)) {
-                                    <span title="{{'scenarios.execution.step.actions.edit' | translate}}"
+                                    <span title="{{'scenarios.execution.step.actions.view' | translate}}"
                                           class="ms-3 action" (click)="openOffCanva(monaco, output.value)">
                     <i class="fa-sm fa-regular fa-eye"></i>
                   </span>

--- a/chutney/ui/src/assets/i18n/en.json
+++ b/chutney/ui/src/assets/i18n/en.json
@@ -99,6 +99,7 @@
                 "actions": {
                     "copy": "Copy value",
                     "edit": "Edit value",
+                    "view": "View value",
                     "collapse.all": "Collapse all",
                     "expand.all": "Expand all",
                     "select.root": "See all steps",

--- a/chutney/ui/src/assets/i18n/fr.json
+++ b/chutney/ui/src/assets/i18n/fr.json
@@ -95,10 +95,11 @@
             "step": {
                 "inputs": "Entrées",
                 "outputs": "Sorties",
-                "inferr": "Logs",
+                "inferr": "Journaux",
                 "actions": {
                     "copy": "Copier la valeur",
                     "edit": "Editer la valeur",
+                    "view": "Voir la valeur",
                     "collapse.all": "Tout replier",
                     "expand.all": "Tout déplier",
                     "select.root": "Tout voir",


### PR DESCRIPTION
<!--
  ~ SPDX-FileCopyrightText: 2017-2024 Enedis
  ~
  ~ SPDX-License-Identifier: Apache-2.0
  ~
  -->

<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made
Fix  tasks inputs/outputs pretty print on execution report:
- should format and escape XML inside json
- should format and escape XML inside array
- should format and escape XML inside json inside array
- should return a pretty array for an array of JSON strings
- should return a pretty array for an array of JSON strings that contains numbers as strings
<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->


#### Test plan <!-- OPTIONAL -->
`prettyPrint.pipe.spec`
<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [x] New code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
