### PR TITLE
Use local docker compose when running ssh acceptance test

### DIFF
--- a/acceptance-tests/src/test/kotlin/fr/enedis/chutney/acceptance/AcceptanceTests.kt
+++ b/acceptance-tests/src/test/kotlin/fr/enedis/chutney/acceptance/AcceptanceTests.kt
@@ -396,6 +396,7 @@ class AcceptanceTests {
     fun setUp() {
       sshContainer =
         ComposeContainer(File("src/test/resources/blackbox/env/ssh/ssh-env-compose.yml"))
+          .withLocalCompose(true)
           .waitingFor("jump-host", Wait.forLogMessage(".*Server listening on.*", 1))
           .waitingFor("intern-host", Wait.forLogMessage(".*Server listening on.*", 1))
           .waitingFor("intern-jump-host", Wait.forLogMessage(".*Server listening on.*", 1))


### PR DESCRIPTION
<!--
  ~ SPDX-FileCopyrightText: 2017-2024 Enedis
  ~
  ~ SPDX-License-Identifier: Apache-2.0
  ~
  -->

#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->
There is network issue when using docker compose and testcontainers:
Sometimes, containers are not attached to all requested internal (in compose file) networks. This specially happens with jump-host or internal-jump-host which are linked to more than one network.
#### Describe the changes you've made

it's impossible to attach a container to more than one network without using docker compose(see [doc](https://java.testcontainers.org/features/networking/#advanced-networking)).

I'm trying to tell testcontainers to use [local compose mode](https://java.testcontainers.org/modules/docker_compose/#the-local-compose-mode).
Let's try and see if it will fails again (local tests are OK)

<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [ ] All new and existing tests pass
- [ ] No git conflict
