### PR TITLE
fix(ui): single click to remove global search table results

### DIFF
--- a/chutney/ui/src/app/shared/components/search-bar/search-bar.component.ts
+++ b/chutney/ui/src/app/shared/components/search-bar/search-bar.component.ts
@@ -74,14 +74,10 @@ export class SearchBarComponent {
 
             const fullUrl = `${baseHref}#${serializedUrl}`;
             window.open(fullUrl, '_blank');
-        } else {
+            this.isSearchExpanded = false;
+        } else if(event.button === 0) {
             this.router.navigate([item.what, this.sanitizeMark(item.id)]);
-        }
-
-        if (!(event.ctrlKey || event.metaKey || event.button === 1)) {
-            setTimeout(() => {
-                this.isSearchExpanded = false;
-            }, 200);
+            this.isSearchExpanded = false;
         }
     }
 


### PR DESCRIPTION
<!--
  ~ SPDX-FileCopyrightText: 2017-2024 Enedis
  ~
  ~ SPDX-License-Identifier: Apache-2.0
  ~
  -->

#### Issue Number
fixes #

#### Describe the changes you've made
UI: global search : double click is needed to go to searched element

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->
NA

#### Test plan <!-- OPTIONAL -->
a quick UI manual test is enough

#### Checklist

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
