### PR TITLE
feat: add metrics on jira calls failures

### DIFF
--- a/chutney/jira/src/main/java/fr/enedis/chutney/jira/JiraSpringConfiguration.java
+++ b/chutney/jira/src/main/java/fr/enedis/chutney/jira/JiraSpringConfiguration.java
@@ -13,6 +13,7 @@ import fr.enedis.chutney.jira.domain.JiraXrayClientFactory;
 import fr.enedis.chutney.jira.domain.JiraXrayService;
 import fr.enedis.chutney.jira.infra.JiraFileRepository;
 import fr.enedis.chutney.jira.infra.JiraXrayFactoryImpl;
+import fr.enedis.chutney.server.core.domain.instrument.ChutneyMetrics;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,8 +33,8 @@ public class JiraSpringConfiguration {
 
     // domain Bean
     @Bean
-    JiraXrayService jiraXrayService(JiraRepository jiraRepository, JiraXrayClientFactory jiraXrayFactory) {
-        return new JiraXrayService(jiraRepository, jiraXrayFactory);
+    JiraXrayService jiraXrayService(JiraRepository jiraRepository, JiraXrayClientFactory jiraXrayFactory, ChutneyMetrics metrics) {
+        return new JiraXrayService(jiraRepository, jiraXrayFactory, metrics);
     }
 
     // infra Bean

--- a/chutney/jira/src/main/java/fr/enedis/chutney/jira/domain/JiraXrayClientFactory.java
+++ b/chutney/jira/src/main/java/fr/enedis/chutney/jira/domain/JiraXrayClientFactory.java
@@ -7,8 +7,10 @@
 
 package fr.enedis.chutney.jira.domain;
 
+import fr.enedis.chutney.server.core.domain.instrument.ChutneyMetrics;
+
 public interface JiraXrayClientFactory {
 
-    JiraXrayApi create(JiraServerConfiguration jiraServerConfiguration);
+    JiraXrayApi create(JiraServerConfiguration jiraServerConfiguration, ChutneyMetrics metrics);
 
 }

--- a/chutney/jira/src/main/java/fr/enedis/chutney/jira/domain/JiraXrayService.java
+++ b/chutney/jira/src/main/java/fr/enedis/chutney/jira/domain/JiraXrayService.java
@@ -19,6 +19,7 @@ import fr.enedis.chutney.jira.xrayapi.XrayEvidence;
 import fr.enedis.chutney.jira.xrayapi.XrayInfo;
 import fr.enedis.chutney.jira.xrayapi.XrayTest;
 import fr.enedis.chutney.jira.xrayapi.XrayTestExecTest;
+import fr.enedis.chutney.server.core.domain.instrument.ChutneyMetrics;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -37,10 +38,12 @@ public class JiraXrayService {
     private final JiraRepository jiraRepository;
     private final JiraXrayClientFactory jiraXrayImplFactory;
     private JiraServerConfiguration jiraServerConfiguration;
+    private final ChutneyMetrics metrics;
 
-    public JiraXrayService(JiraRepository jiraRepository, JiraXrayClientFactory jiraXrayImplFactory) {
+    public JiraXrayService(JiraRepository jiraRepository, JiraXrayClientFactory jiraXrayImplFactory, ChutneyMetrics metrics) {
         this.jiraRepository = jiraRepository;
         this.jiraXrayImplFactory = jiraXrayImplFactory;
+        this.metrics = metrics;
         loadJiraServerConfiguration();
     }
 
@@ -112,7 +115,7 @@ public class JiraXrayService {
         if (!loadJiraServerConfiguration()) {
             throw new NoJiraConfigurationException();
         }
-        return jiraXrayImplFactory.create(jiraServerConfiguration);
+        return jiraXrayImplFactory.create(jiraServerConfiguration, metrics);
     }
 
     private List<String> getErrors(ReportForJira report) {

--- a/chutney/jira/src/main/java/fr/enedis/chutney/jira/infra/JiraXrayFactoryImpl.java
+++ b/chutney/jira/src/main/java/fr/enedis/chutney/jira/infra/JiraXrayFactoryImpl.java
@@ -10,12 +10,13 @@ package fr.enedis.chutney.jira.infra;
 import fr.enedis.chutney.jira.domain.JiraServerConfiguration;
 import fr.enedis.chutney.jira.domain.JiraXrayApi;
 import fr.enedis.chutney.jira.domain.JiraXrayClientFactory;
+import fr.enedis.chutney.server.core.domain.instrument.ChutneyMetrics;
 
 public class JiraXrayFactoryImpl implements JiraXrayClientFactory {
 
     @Override
-    public JiraXrayApi create(JiraServerConfiguration jiraServerConfiguration) {
-        return new HttpJiraXrayImpl(jiraServerConfiguration);
+    public JiraXrayApi create(JiraServerConfiguration jiraServerConfiguration, ChutneyMetrics metrics) {
+        return new HttpJiraXrayImpl(jiraServerConfiguration, metrics);
     }
 
 }

--- a/chutney/jira/src/test/java/fr/enedis/chutney/jira/api/JiraControllerTest.java
+++ b/chutney/jira/src/test/java/fr/enedis/chutney/jira/api/JiraControllerTest.java
@@ -28,6 +28,7 @@ import fr.enedis.chutney.jira.domain.JiraXrayClientFactory;
 import fr.enedis.chutney.jira.domain.JiraXrayService;
 import fr.enedis.chutney.jira.infra.JiraFileRepository;
 import fr.enedis.chutney.jira.xrayapi.XrayTestExecTest;
+import fr.enedis.chutney.server.core.domain.instrument.ChutneyMetrics;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -53,9 +54,9 @@ class JiraControllerTest {
     @BeforeEach
     public void setUp() throws IOException {
         jiraRepository = new JiraFileRepository(Files.createTempDirectory("jira").toString());
-        JiraXrayService jiraXrayService = new JiraXrayService(jiraRepository, jiraXrayFactory);
+        JiraXrayService jiraXrayService = new JiraXrayService(jiraRepository, jiraXrayFactory, mock(ChutneyMetrics.class));
 
-        when(jiraXrayFactory.create(any())).thenReturn(mockJiraXrayApi);
+        when(jiraXrayFactory.create(any(), any())).thenReturn(mockJiraXrayApi);
 
         jiraRepository.saveServerConfiguration(new JiraServerConfiguration("an url", "a username", "a password", null, null, null));
         jiraRepository.saveForCampaign("10", "JIRA-10");

--- a/chutney/jira/src/test/java/fr/enedis/chutney/jira/api/JiraXrayEmbeddedApiTest.java
+++ b/chutney/jira/src/test/java/fr/enedis/chutney/jira/api/JiraXrayEmbeddedApiTest.java
@@ -27,6 +27,7 @@ import fr.enedis.chutney.jira.infra.JiraFileRepository;
 import fr.enedis.chutney.jira.xrayapi.Xray;
 import fr.enedis.chutney.jira.xrayapi.XrayTest;
 import fr.enedis.chutney.jira.xrayapi.XrayTestExecTest;
+import fr.enedis.chutney.server.core.domain.instrument.ChutneyMetrics;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.time.Instant;
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 class JiraXrayEmbeddedApiTest {
 
@@ -57,9 +59,9 @@ class JiraXrayEmbeddedApiTest {
         jiraRepository = new JiraFileRepository(Files.createTempDirectory("jira").toString());
         jiraRepository.saveServerConfiguration(jiraServerConfiguration);
 
-        JiraXrayService jiraXrayService = new JiraXrayService(jiraRepository, jiraXrayFactory);
+        JiraXrayService jiraXrayService = new JiraXrayService(jiraRepository, jiraXrayFactory, Mockito.mock(ChutneyMetrics.class));
 
-        when(jiraXrayFactory.create(any())).thenReturn(jiraXrayApiMock);
+        when(jiraXrayFactory.create(any(), any())).thenReturn(jiraXrayApiMock);
 
         jiraXrayEmbeddedApi = new JiraXrayEmbeddedApi(jiraXrayService);
     }

--- a/chutney/jira/src/test/java/fr/enedis/chutney/jira/domain/JiraXrayServiceTest.java
+++ b/chutney/jira/src/test/java/fr/enedis/chutney/jira/domain/JiraXrayServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import fr.enedis.chutney.jira.domain.exception.NoJiraConfigurationException;
+import fr.enedis.chutney.server.core.domain.instrument.ChutneyMetrics;
 import java.lang.reflect.Field;
 import org.junit.jupiter.api.Test;
 
@@ -28,10 +29,11 @@ class JiraXrayServiceTest {
         when(jiraRepository.loadServerConfiguration()).thenReturn(initialJiraConfiguration);
 
         var jiraXrayClientFactory = mock(JiraXrayClientFactory.class);
+        var metrics = mock(ChutneyMetrics.class);
         var jiraXrayApi = mock(JiraXrayApi.class);
-        when(jiraXrayClientFactory.create(any())).thenReturn(jiraXrayApi);
+        when(jiraXrayClientFactory.create(any(), any())).thenReturn(jiraXrayApi);
 
-        JiraXrayService sut = new JiraXrayService(jiraRepository, jiraXrayClientFactory);
+        JiraXrayService sut = new JiraXrayService(jiraRepository, jiraXrayClientFactory, metrics);
         Field jiraConfigurationField = sut.getClass().getDeclaredField("jiraServerConfiguration");
         jiraConfigurationField.setAccessible(true);
 

--- a/chutney/jira/src/test/java/fr/enedis/chutney/jira/infra/HttpJiraXrayImplTest.java
+++ b/chutney/jira/src/test/java/fr/enedis/chutney/jira/infra/HttpJiraXrayImplTest.java
@@ -22,6 +22,7 @@ import fr.enedis.chutney.jira.domain.JiraServerConfiguration;
 import fr.enedis.chutney.jira.xrayapi.Xray;
 import fr.enedis.chutney.jira.xrayapi.XrayInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import fr.enedis.chutney.server.core.domain.instrument.ChutneyMetrics;
 import java.net.UnknownHostException;
 import java.util.Base64;
 import java.util.List;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
 
 public class HttpJiraXrayImplTest {
 
@@ -58,7 +60,7 @@ public class HttpJiraXrayImplTest {
             );
 
             // When/Then
-            HttpJiraXrayImpl httpJiraXray = new HttpJiraXrayImpl(config);
+            HttpJiraXrayImpl httpJiraXray = new HttpJiraXrayImpl(config, Mockito.mock(ChutneyMetrics.class));
             assertThatThrownBy(() ->
                 httpJiraXray.updateRequest(new Xray("test", List.of(), new XrayInfo(List.of())))
             )
@@ -82,7 +84,7 @@ public class HttpJiraXrayImplTest {
             );
 
             // When/Then
-            var sut = new HttpJiraXrayImpl(config);
+            var sut = new HttpJiraXrayImpl(config, Mockito.mock(ChutneyMetrics.class));
             assertThatThrownBy(() ->
                 sut.isTestPlan(issueId)
             )
@@ -104,7 +106,7 @@ public class HttpJiraXrayImplTest {
                 "",
                 ""
             );
-            var sut = new HttpJiraXrayImpl(config);
+            var sut = new HttpJiraXrayImpl(config, Mockito.mock(ChutneyMetrics.class));
 
             // When
             boolean result = sut.isTestPlan(issueId);
@@ -135,7 +137,7 @@ public class HttpJiraXrayImplTest {
             );
 
             // When
-            HttpJiraXrayImpl httpJiraXray = new HttpJiraXrayImpl(config);
+            HttpJiraXrayImpl httpJiraXray = new HttpJiraXrayImpl(config, Mockito.mock(ChutneyMetrics.class));
             httpJiraXray.updateRequest(new Xray("test", List.of(), new XrayInfo(List.of())));
 
             // Then
@@ -220,7 +222,7 @@ public class HttpJiraXrayImplTest {
             );
 
             // When
-            var sut = new HttpJiraXrayImpl(config);
+            var sut = new HttpJiraXrayImpl(config, Mockito.mock(ChutneyMetrics.class));
             boolean isTestPlan = sut.isTestPlan(issueId);
 
             // Then
@@ -254,7 +256,7 @@ public class HttpJiraXrayImplTest {
             );
 
             // When
-            HttpJiraXrayImpl httpJiraXray = new HttpJiraXrayImpl(config);
+            HttpJiraXrayImpl httpJiraXray = new HttpJiraXrayImpl(config, Mockito.mock(ChutneyMetrics.class));
             httpJiraXray.updateRequest(new Xray("test", List.of(), new XrayInfo(List.of())));
 
             // Then
@@ -339,7 +341,7 @@ public class HttpJiraXrayImplTest {
             );
 
             // When
-            var sut = new HttpJiraXrayImpl(config);
+            var sut = new HttpJiraXrayImpl(config, Mockito.mock(ChutneyMetrics.class));
             boolean isTestPlan = sut.isTestPlan(issueId);
 
             // Then

--- a/chutney/server-core/src/main/java/fr/enedis/chutney/server/core/domain/instrument/ChutneyMetrics.java
+++ b/chutney/server-core/src/main/java/fr/enedis/chutney/server/core/domain/instrument/ChutneyMetrics.java
@@ -20,4 +20,6 @@ public interface ChutneyMetrics {
     void onCampaignExecutionEnded(Campaign campaign, CampaignExecution campaignExecution);
 
     void onHttpError(HttpStatusCode status);
+
+    void onJiraRestClientError(HttpStatusCode status);
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/instrument/infra/MicrometerMetrics.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/instrument/infra/MicrometerMetrics.java
@@ -82,6 +82,12 @@ public class MicrometerMetrics implements ChutneyMetrics {
         httpErrorCount.increment();
     }
 
+    @Override
+    public void onJiraRestClientError(HttpStatusCode status) {
+        final Counter jiraRestClientErrorCount = this.meterRegistry.counter("jira_rest_client_error", List.of(of("status", String.valueOf(status.value()))));
+        jiraRestClientErrorCount.increment();
+    }
+
     private void updateMetrics(Map<ServerReportStatus, Long> scenarioCountByStatus, Map<ServerReportStatus, AtomicLong> cachedMetrics) {
         cachedMetrics.forEach((key, value) -> {
             final Long valueInCache = scenarioCountByStatus.get(key);


### PR DESCRIPTION
<!--
  ~ SPDX-FileCopyrightText: 2017-2024 Enedis
  ~
  ~ SPDX-License-Identifier: Apache-2.0
  ~
  -->

#### Issue Number
"Rate limiting on JIra API"

#### Describe the changes you've made
Adds metrics on jira rest client failures. This metric can be used to detect TooManyRequests response status code when calling Jira Xray

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->
NA

#### Additional context <!-- OPTIONAL -->
NA

#### Test plan <!-- OPTIONAL -->
A Jira instance enabling Xray is needed. Rate limiting must be activated on the Jira instance. A running Chutney server is needed too

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
