### PR TITLE
Personal tokens by API key in synchronization

### DIFF
--- a/chutney/server/src/main/java/fr/enedis/chutney/security/ApiKeyAuthentication.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/ApiKeyAuthentication.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.security;
+
+import fr.enedis.chutney.security.api.UserDto;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class ApiKeyAuthentication extends AbstractAuthenticationToken {
+
+    public ApiKeyAuthentication(Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        UserDto user = new UserDto();
+        user.setId("NAME");
+        user.setName("NAME");
+        user.setMail("NAME@etc.com");
+        user.setFirstname("NAME");
+        user.setLastname("NAME");
+        user.setRoles(getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet()));
+        return user;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        UserDto user = new UserDto();
+        user.setId("NAME");
+        user.setName("NAME");
+        user.setMail("NAME@etc.com");
+        user.setFirstname("NAME");
+        user.setLastname("NAME");
+        user.setRoles(getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet()));
+        return user;
+    }
+}

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/ApiKeyAuthentication.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/ApiKeyAuthentication.java
@@ -15,19 +15,19 @@ import org.springframework.security.core.GrantedAuthority;
 
 public class ApiKeyAuthentication extends AbstractAuthenticationToken {
 
-    public ApiKeyAuthentication(Collection<? extends GrantedAuthority> authorities) {
+    private final String userName;
+
+    public ApiKeyAuthentication(String userName, Collection<? extends GrantedAuthority> authorities) {
         super(authorities);
+        this.userName = userName;
         setAuthenticated(true);
     }
 
     @Override
     public Object getCredentials() {
         UserDto user = new UserDto();
-        user.setId("NAME");
-        user.setName("NAME");
-        user.setMail("NAME@etc.com");
-        user.setFirstname("NAME");
-        user.setLastname("NAME");
+        user.setId(userName);
+        user.setName(userName);
         user.setRoles(getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet()));
         return user;
     }
@@ -35,11 +35,8 @@ public class ApiKeyAuthentication extends AbstractAuthenticationToken {
     @Override
     public Object getPrincipal() {
         UserDto user = new UserDto();
-        user.setId("NAME");
-        user.setName("NAME");
-        user.setMail("NAME@etc.com");
-        user.setFirstname("NAME");
-        user.setLastname("NAME");
+        user.setId(userName);
+        user.setName(userName);
         user.setRoles(getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet()));
         return user;
     }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/ApiKeyAuthentication.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/ApiKeyAuthentication.java
@@ -16,20 +16,18 @@ import org.springframework.security.core.GrantedAuthority;
 public class ApiKeyAuthentication extends AbstractAuthenticationToken {
 
     private final String userName;
+    private final String hashedToken;
 
-    public ApiKeyAuthentication(String userName, Collection<? extends GrantedAuthority> authorities) {
+    public ApiKeyAuthentication(String userName, String hashedToken, Collection<? extends GrantedAuthority> authorities) {
         super(authorities);
         this.userName = userName;
+        this.hashedToken = hashedToken;
         setAuthenticated(true);
     }
 
     @Override
     public Object getCredentials() {
-        UserDto user = new UserDto();
-        user.setId(userName);
-        user.setName(userName);
-        user.setRoles(getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet()));
-        return user;
+        return hashedToken;
     }
 
     @Override

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/ApiKeyAuthentication.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/ApiKeyAuthentication.java
@@ -8,18 +8,19 @@
 package fr.enedis.chutney.security;
 
 import fr.enedis.chutney.security.api.UserDto;
-import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
 
 public class ApiKeyAuthentication extends AbstractAuthenticationToken {
 
     private final String userName;
     private final String hashedToken;
 
-    public ApiKeyAuthentication(String userName, String hashedToken, Collection<? extends GrantedAuthority> authorities) {
-        super(authorities);
+    public ApiKeyAuthentication(String userName, String hashedToken, List<String> authorities) {
+        super(AuthorityUtils.createAuthorityList(authorities));
         this.userName = userName;
         this.hashedToken = hashedToken;
         setAuthenticated(true);

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/ChutneyWebSecurityConfig.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/ChutneyWebSecurityConfig.java
@@ -65,6 +65,7 @@ import org.springframework.security.oauth2.server.resource.introspection.OpaqueT
 import org.springframework.security.oauth2.server.resource.introspection.SpringOpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFilter;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.web.client.RestOperations;
@@ -191,7 +192,7 @@ public class ChutneyWebSecurityConfig {
             )
             .httpBasic(Customizer.withDefaults())
             .addFilterBefore(new CorsFilter(corsConfigurationSource), BearerTokenAuthenticationFilter.class)
-            .addFilterBefore(apiAuthenticationFilter, BearerTokenAuthenticationFilter.class)
+            .addFilterBefore(apiAuthenticationFilter, AuthenticationFilter.class)
             .addFilterAfter(oAuth2TokenAuthenticationFilter, BearerTokenAuthenticationFilter.class);
         return http.build();
     }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/ChutneyWebSecurityConfig.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/ChutneyWebSecurityConfig.java
@@ -18,6 +18,7 @@ import fr.enedis.chutney.security.api.AuthenticationConfigController;
 import fr.enedis.chutney.security.api.UserController;
 import fr.enedis.chutney.security.api.UserDto;
 import fr.enedis.chutney.security.domain.AuthenticationService;
+import fr.enedis.chutney.security.infra.ApiAuthenticationFilter;
 import fr.enedis.chutney.security.infra.jwt.ChutneyJwtAuthenticationConverter;
 import fr.enedis.chutney.security.infra.jwt.ChutneyJwtProperties;
 import fr.enedis.chutney.security.infra.jwt.JwtUtil;
@@ -123,6 +124,11 @@ public class ChutneyWebSecurityConfig {
         return (request) -> useJwt(request) ? jwt : opaqueToken;
     }
 
+    @Bean
+    ApiAuthenticationFilter apiAuthenticationFilter(AuthenticationService authenticationService) {
+        return new ApiAuthenticationFilter(authenticationService);
+    }
+
     private boolean useJwt(HttpServletRequest request) {
         String authorizationHeader = request.getHeader("Authorization");
         if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
@@ -152,7 +158,10 @@ public class ChutneyWebSecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(final HttpSecurity http, AuthenticationManagerResolver<HttpServletRequest> tokenAuthenticationManagerResolver, OAuth2TokenAuthenticationFilter oAuth2TokenAuthenticationFilter, JwtUtil jwtUtil, CorsConfigurationSource corsConfigurationSource) throws Exception {
+    public SecurityFilterChain securityFilterChain(final HttpSecurity http, AuthenticationManagerResolver<HttpServletRequest> tokenAuthenticationManagerResolver, OAuth2TokenAuthenticationFilter oAuth2TokenAuthenticationFilter,
+                                                   JwtUtil jwtUtil,
+                                                   ApiAuthenticationFilter apiAuthenticationFilter,
+                                                   CorsConfigurationSource corsConfigurationSource) throws Exception {
         configureBaseHttpSecurity(http);
         UserDto anonymous = anonymous();
         var path = PathPatternRequestMatcher.withDefaults();
@@ -182,6 +191,7 @@ public class ChutneyWebSecurityConfig {
             )
             .httpBasic(Customizer.withDefaults())
             .addFilterBefore(new CorsFilter(corsConfigurationSource), BearerTokenAuthenticationFilter.class)
+            .addFilterBefore(apiAuthenticationFilter, BearerTokenAuthenticationFilter.class)
             .addFilterAfter(oAuth2TokenAuthenticationFilter, BearerTokenAuthenticationFilter.class);
         return http.build();
     }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/SecurityConfiguration.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/SecurityConfiguration.java
@@ -9,6 +9,7 @@ package fr.enedis.chutney.security;
 
 import fr.enedis.chutney.security.domain.AuthenticationService;
 import fr.enedis.chutney.security.domain.Authorizations;
+import fr.enedis.chutney.tokens.domain.AccessTokensService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -16,7 +17,8 @@ import org.springframework.context.annotation.Configuration;
 public class SecurityConfiguration {
 
     @Bean
-    public AuthenticationService authenticationService(Authorizations  authorizations) {
-        return new AuthenticationService(authorizations);
+    public AuthenticationService authenticationService(Authorizations authorizations,
+                                                       AccessTokensService accessTokensService) {
+        return new AuthenticationService(authorizations, accessTokensService);
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
@@ -45,7 +45,7 @@ public class AuthenticationService {
 
     public Authentication getAuthentication(String apiKey, String requestURI) {
 
-        var user = accessTokensService.userFromToken(apiKey);
+        var user = accessTokensService.accessTokenFromRaw(apiKey);
         if (user.isEmpty()) {
             LOGGER.info("Wrong Api-key for request {}", requestURI);
             throw new BadCredentialsException("Invalid API Key");

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
@@ -13,10 +13,8 @@ import fr.enedis.chutney.server.core.domain.security.Role;
 import fr.enedis.chutney.server.core.domain.security.RoleNotFoundException;
 import fr.enedis.chutney.server.core.domain.security.User;
 import fr.enedis.chutney.server.core.domain.security.UserRoles;
-import fr.enedis.chutney.tokens.domain.AccessToken;
 import fr.enedis.chutney.tokens.domain.AccessTokensService;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -47,7 +45,7 @@ public class AuthenticationService {
 
     public Authentication getAuthentication(String apiKey, String requestURI) {
 
-        Optional<AccessToken> user = accessTokensService.userFromToken(apiKey);
+        var user = accessTokensService.userFromToken(apiKey);
         if (user.isEmpty()) {
             LOGGER.info("Wrong Api-key for request {}", requestURI);
             throw new BadCredentialsException("Invalid API Key");

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
@@ -15,7 +15,10 @@ import fr.enedis.chutney.server.core.domain.security.User;
 import fr.enedis.chutney.server.core.domain.security.UserRoles;
 import fr.enedis.chutney.tokens.domain.AccessToken;
 import fr.enedis.chutney.tokens.domain.AccessTokensService;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -50,11 +53,15 @@ public class AuthenticationService {
             throw new BadCredentialsException("Invalid API Key");
         }
 
-        LOGGER.info("Api-key authentication success for user {} and for request {}", user.get().user(), requestURI);
+        String userName = user.get().user();
+        LOGGER.info("Api-key authentication success for user {} and for request {}", userName, requestURI);
 
-        return new ApiKeyAuthentication(user.get().user(), user.get().hash(),
-            AuthorityUtils.createAuthorityList(
-                Authorization.SCENARIO_WRITE.name(),
-                Authorization.SCENARIO_READ.name()));
+        Set<Authorization> userAuthorizations = this.userRoleById(userName).authorizations;
+        List<String> authorities = userAuthorizations
+            .stream()
+            .map(Enum::name)
+            .collect(Collectors.toList());
+        return new ApiKeyAuthentication(userName, user.get().hash(),
+            AuthorityUtils.createAuthorityList(authorities));
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
@@ -52,6 +52,6 @@ public class AuthenticationService {
 
         LOGGER.info("Api-key authentication success for user {} and for request {}", user.get(), requestURI);
 
-        return new ApiKeyAuthentication(user.get().user(), user.get().hashedToken(), AuthorityUtils.createAuthorityList(Authorization.SCENARIO_WRITE.name()));
+        return new ApiKeyAuthentication(user.get().user(), user.get().hash(), AuthorityUtils.createAuthorityList(Authorization.SCENARIO_WRITE.name()));
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
@@ -15,6 +15,7 @@ import fr.enedis.chutney.server.core.domain.security.User;
 import fr.enedis.chutney.server.core.domain.security.UserRoles;
 import fr.enedis.chutney.tokens.domain.AccessTokensService;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -45,13 +46,15 @@ public class AuthenticationService {
 
     public Authentication getAuthentication(HttpServletRequest request) {
         String apiKey = request.getHeader(AUTH_TOKEN_HEADER_NAME);
-        LOGGER.info("Trying to authenticate apiKey for request {}", request.getRequestURI());
 
-        if (apiKey == null || !accessTokensService.matchToken(apiKey)) {
-            LOGGER.info("Wrong apiKey for request {}", request.getRequestURI());
+        Optional<String> user = accessTokensService.userFromToken(apiKey);
+        if (apiKey == null || user.isEmpty()) {
+            LOGGER.info("Wrong Api-key for request {}", request.getRequestURI());
             throw new BadCredentialsException("Invalid API Key");
         }
 
-        return new ApiKeyAuthentication(AuthorityUtils.createAuthorityList(Authorization.SCENARIO_WRITE.name()));
+        LOGGER.info("Api-key authentication success for user {} and for request {}", user.get(), request.getRequestURI());
+
+        return new ApiKeyAuthentication(user.get(), AuthorityUtils.createAuthorityList(Authorization.SCENARIO_WRITE.name()));
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
@@ -7,17 +7,33 @@
 
 package fr.enedis.chutney.security.domain;
 
+import fr.enedis.chutney.security.ApiKeyAuthentication;
+import fr.enedis.chutney.server.core.domain.security.Authorization;
 import fr.enedis.chutney.server.core.domain.security.Role;
 import fr.enedis.chutney.server.core.domain.security.RoleNotFoundException;
 import fr.enedis.chutney.server.core.domain.security.User;
 import fr.enedis.chutney.server.core.domain.security.UserRoles;
+import fr.enedis.chutney.tokens.domain.AccessTokensService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
 
 public class AuthenticationService {
 
     private final Authorizations authorizations;
+    private final AccessTokensService accessTokensService;
 
-    public AuthenticationService(Authorizations authorizations) {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationService.class);
+
+    private static final String AUTH_TOKEN_HEADER_NAME = "X-API-KEY";
+
+    public AuthenticationService(Authorizations authorizations,
+                                 AccessTokensService accessTokensService) {
         this.authorizations = authorizations;
+        this.accessTokensService = accessTokensService;
     }
 
     public Role userRoleById(String userId) {
@@ -25,5 +41,17 @@ public class AuthenticationService {
         User user = userRoles.userById(userId)
             .orElseThrow(() -> RoleNotFoundException.forUser(userId));
         return userRoles.roleByName(user.roleName);
+    }
+
+    public Authentication getAuthentication(HttpServletRequest request) {
+        String apiKey = request.getHeader(AUTH_TOKEN_HEADER_NAME);
+        LOGGER.info("Trying to authenticate apiKey for request {}", request.getRequestURI());
+
+        if (apiKey == null || !accessTokensService.matchToken(apiKey)) {
+            LOGGER.info("Wrong apiKey for request {}", request.getRequestURI());
+            throw new BadCredentialsException("Invalid API Key");
+        }
+
+        return new ApiKeyAuthentication(AuthorityUtils.createAuthorityList(Authorization.SCENARIO_WRITE.name()));
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
@@ -15,7 +15,6 @@ import fr.enedis.chutney.server.core.domain.security.User;
 import fr.enedis.chutney.server.core.domain.security.UserRoles;
 import fr.enedis.chutney.tokens.domain.AccessToken;
 import fr.enedis.chutney.tokens.domain.AccessTokensService;
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,8 +29,6 @@ public class AuthenticationService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationService.class);
 
-    private static final String AUTH_TOKEN_HEADER_NAME = "X-API-KEY";
-
     public AuthenticationService(Authorizations authorizations,
                                  AccessTokensService accessTokensService) {
         this.authorizations = authorizations;
@@ -45,16 +42,15 @@ public class AuthenticationService {
         return userRoles.roleByName(user.roleName);
     }
 
-    public Authentication getAuthentication(HttpServletRequest request) {
-        String apiKey = request.getHeader(AUTH_TOKEN_HEADER_NAME);
+    public Authentication getAuthentication(String apiKey, String requestURI) {
 
         Optional<AccessToken> user = accessTokensService.userFromToken(apiKey);
-        if (apiKey == null || user.isEmpty()) {
-            LOGGER.info("Wrong Api-key for request {}", request.getRequestURI());
+        if (user.isEmpty()) {
+            LOGGER.info("Wrong Api-key for request {}", requestURI);
             throw new BadCredentialsException("Invalid API Key");
         }
 
-        LOGGER.info("Api-key authentication success for user {} and for request {}", user.get(), request.getRequestURI());
+        LOGGER.info("Api-key authentication success for user {} and for request {}", user.get(), requestURI);
 
         return new ApiKeyAuthentication(user.get().user(), user.get().hashedToken(), AuthorityUtils.createAuthorityList(Authorization.SCENARIO_WRITE.name()));
     }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
@@ -13,6 +13,7 @@ import fr.enedis.chutney.server.core.domain.security.Role;
 import fr.enedis.chutney.server.core.domain.security.RoleNotFoundException;
 import fr.enedis.chutney.server.core.domain.security.User;
 import fr.enedis.chutney.server.core.domain.security.UserRoles;
+import fr.enedis.chutney.tokens.domain.AccessToken;
 import fr.enedis.chutney.tokens.domain.AccessTokensService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
@@ -47,7 +48,7 @@ public class AuthenticationService {
     public Authentication getAuthentication(HttpServletRequest request) {
         String apiKey = request.getHeader(AUTH_TOKEN_HEADER_NAME);
 
-        Optional<String> user = accessTokensService.userFromToken(apiKey);
+        Optional<AccessToken> user = accessTokensService.userFromToken(apiKey);
         if (apiKey == null || user.isEmpty()) {
             LOGGER.info("Wrong Api-key for request {}", request.getRequestURI());
             throw new BadCredentialsException("Invalid API Key");
@@ -55,6 +56,6 @@ public class AuthenticationService {
 
         LOGGER.info("Api-key authentication success for user {} and for request {}", user.get(), request.getRequestURI());
 
-        return new ApiKeyAuthentication(user.get(), AuthorityUtils.createAuthorityList(Authorization.SCENARIO_WRITE.name()));
+        return new ApiKeyAuthentication(user.get().user(), user.get().hashedToken(), AuthorityUtils.createAuthorityList(Authorization.SCENARIO_WRITE.name()));
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
@@ -47,12 +47,12 @@ public class AuthenticationService {
 
         var user = accessTokensService.accessTokenFromRaw(apiKey);
         if (user.isEmpty()) {
-            LOGGER.info("Wrong Api-key for request {}", requestURI);
+            LOGGER.info("Wrong Api Key for request {}", requestURI);
             throw new BadCredentialsException("Invalid API Key");
         }
 
         String userName = user.get().user();
-        LOGGER.info("Api-key authentication success for user {} and for request {}", userName, requestURI);
+        LOGGER.info("Api Key authentication success for user {} and for request {}", userName, requestURI);
 
         Set<Authorization> userAuthorizations = this.userRoleById(userName).authorizations;
         List<String> authorities = userAuthorizations

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
@@ -50,8 +50,11 @@ public class AuthenticationService {
             throw new BadCredentialsException("Invalid API Key");
         }
 
-        LOGGER.info("Api-key authentication success for user {} and for request {}", user.get(), requestURI);
+        LOGGER.info("Api-key authentication success for user {} and for request {}", user.get().user(), requestURI);
 
-        return new ApiKeyAuthentication(user.get().user(), user.get().hash(), AuthorityUtils.createAuthorityList(Authorization.SCENARIO_WRITE.name()));
+        return new ApiKeyAuthentication(user.get().user(), user.get().hash(),
+            AuthorityUtils.createAuthorityList(
+                Authorization.SCENARIO_WRITE.name(),
+                Authorization.SCENARIO_READ.name()));
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/domain/AuthenticationService.java
@@ -19,9 +19,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.AuthorityUtils;
 
 public class AuthenticationService {
 
@@ -43,23 +40,24 @@ public class AuthenticationService {
         return userRoles.roleByName(user.roleName);
     }
 
-    public Authentication getAuthentication(String apiKey, String requestURI) {
+    /**
+     * @throws InvalidApiKeyException if the api key is incorrect or expired
+     */
+    public ApiKeyAuthentication getAuthentication(String apiKey) {
 
-        var user = accessTokensService.accessTokenFromRaw(apiKey);
-        if (user.isEmpty()) {
-            LOGGER.info("Wrong Api Key for request {}", requestURI);
-            throw new BadCredentialsException("Invalid API Key");
+        var accessToken = accessTokensService.accessTokenFromRaw(apiKey);
+        if (accessToken.isEmpty()) {
+            throw new InvalidApiKeyException();
         }
 
-        String userName = user.get().user();
-        LOGGER.info("Api Key authentication success for user {} and for request {}", userName, requestURI);
+        String userName = accessToken.get().user();
+        LOGGER.info("Api Key authentication success for user {}", userName);
 
         Set<Authorization> userAuthorizations = this.userRoleById(userName).authorizations;
         List<String> authorities = userAuthorizations
             .stream()
             .map(Enum::name)
             .collect(Collectors.toList());
-        return new ApiKeyAuthentication(userName, user.get().hash(),
-            AuthorityUtils.createAuthorityList(authorities));
+        return new ApiKeyAuthentication(userName, accessToken.get().hash(), authorities);
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/domain/InvalidApiKeyException.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/domain/InvalidApiKeyException.java
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.security.domain;
+
+public class InvalidApiKeyException extends RuntimeException {
+
+    public InvalidApiKeyException() {
+        super("Invalid API Key");
+    }
+}

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
@@ -7,6 +7,8 @@
 
 package fr.enedis.chutney.security.infra;
 
+import fr.enedis.chutney.campaign.api.CampaignController;
+import fr.enedis.chutney.dataset.api.DataSetController;
 import fr.enedis.chutney.scenario.api.GwtTestCaseController;
 import fr.enedis.chutney.security.domain.AuthenticationService;
 import jakarta.servlet.FilterChain;
@@ -25,7 +27,9 @@ import org.springframework.web.filter.GenericFilterBean;
 public class ApiAuthenticationFilter extends GenericFilterBean {
 
     private static final Collection<String> API_PATHS = List.of(
-        GwtTestCaseController.BASE_URL + "/raw");
+        GwtTestCaseController.BASE_URL + "/raw",
+        DataSetController.BASE_URL,
+        CampaignController.BASE_URL);
 
     private static final String AUTH_TOKEN_HEADER_NAME = "X-API-KEY";
 

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
@@ -27,11 +27,14 @@ import org.springframework.web.filter.GenericFilterBean;
 
 public class ApiAuthenticationFilter extends GenericFilterBean {
 
-    private static final Collection<String> API_PATHS = List.of(
-        GwtTestCaseController.BASE_URL + "/raw",
-        DataSetController.BASE_URL,
-        CampaignController.BASE_URL,
-        EnvironmentController.BASE_URL);
+    private static final Collection<ApiKeyEndpoint> API_ENDPOINTS = List.of(
+        new ApiKeyEndpoint("GET", GwtTestCaseController.BASE_URL),
+        new ApiKeyEndpoint("POST", GwtTestCaseController.BASE_URL + "/raw"),
+        new ApiKeyEndpoint("GET", DataSetController.BASE_URL),
+        new ApiKeyEndpoint("POST", DataSetController.BASE_URL),
+        new ApiKeyEndpoint("PUT", DataSetController.BASE_URL),
+        new ApiKeyEndpoint("POST", CampaignController.BASE_URL),
+        new ApiKeyEndpoint("GET",EnvironmentController.BASE_URL));
 
     private static final String AUTH_TOKEN_HEADER_NAME = "X-API-KEY";
 
@@ -47,7 +50,7 @@ public class ApiAuthenticationFilter extends GenericFilterBean {
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
         String requestURI = httpServletRequest.getRequestURI();
         try {
-            if(API_PATHS.contains(requestURI)) {
+            if(API_ENDPOINTS.contains(new ApiKeyEndpoint(httpServletRequest.getMethod(), requestURI))) {
                 String apiKey = httpServletRequest.getHeader(AUTH_TOKEN_HEADER_NAME);
                 if(apiKey != null) {
                     Authentication authentication = authenticationService.getAuthentication(apiKey, requestURI);
@@ -65,4 +68,6 @@ public class ApiAuthenticationFilter extends GenericFilterBean {
             printWriter.close();
         }
     }
+
+    private record ApiKeyEndpoint(String method, String path){}
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
@@ -59,9 +59,9 @@ public class ApiAuthenticationFilter extends GenericFilterBean {
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
         String requestURI = httpServletRequest.getRequestURI();
         try {
-            if(matchers.stream().anyMatch(matcher -> matcher.matches(httpServletRequest))) {
-                String apiKey = httpServletRequest.getHeader(AUTH_TOKEN_HEADER_NAME);
-                if(apiKey != null) {
+            String apiKey = httpServletRequest.getHeader(AUTH_TOKEN_HEADER_NAME);
+            if(apiKey != null) {
+                if(matchers.stream().anyMatch(matcher -> matcher.matches(httpServletRequest))) {
                     Authentication authentication = authenticationService.getAuthentication(apiKey, requestURI);
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
@@ -18,30 +18,39 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.web.filter.GenericFilterBean;
 
 public class ApiAuthenticationFilter extends GenericFilterBean {
 
     private static final Collection<ApiKeyEndpoint> API_ENDPOINTS = List.of(
-        new ApiKeyEndpoint("GET", GwtTestCaseController.BASE_URL),
-        new ApiKeyEndpoint("POST", GwtTestCaseController.BASE_URL + "/raw"),
-        new ApiKeyEndpoint("GET", DataSetController.BASE_URL),
-        new ApiKeyEndpoint("POST", DataSetController.BASE_URL),
-        new ApiKeyEndpoint("PUT", DataSetController.BASE_URL),
-        new ApiKeyEndpoint("POST", CampaignController.BASE_URL),
-        new ApiKeyEndpoint("GET", EnvironmentController.BASE_URL));
+        new ApiKeyEndpoint(HttpMethod.GET, GwtTestCaseController.BASE_URL),
+        new ApiKeyEndpoint(HttpMethod.POST, GwtTestCaseController.BASE_URL + "/raw"),
+        new ApiKeyEndpoint(HttpMethod.GET, GwtTestCaseController.BASE_URL + "/raw/**"),
+        new ApiKeyEndpoint(HttpMethod.GET, DataSetController.BASE_URL),
+        new ApiKeyEndpoint(HttpMethod.POST, DataSetController.BASE_URL),
+        new ApiKeyEndpoint(HttpMethod.PUT, DataSetController.BASE_URL),
+        new ApiKeyEndpoint(HttpMethod.POST, CampaignController.BASE_URL),
+        new ApiKeyEndpoint(HttpMethod.GET, EnvironmentController.BASE_URL));
 
     private static final String AUTH_TOKEN_HEADER_NAME = "X-API-KEY";
 
     private final AuthenticationService authenticationService;
+    private final Collection<PathPatternRequestMatcher> matchers;
 
     public ApiAuthenticationFilter(AuthenticationService authenticationService) {
         this.authenticationService = authenticationService;
+
+        PathPatternRequestMatcher.Builder builder = PathPatternRequestMatcher.withDefaults();
+        matchers = new ArrayList<>();
+        API_ENDPOINTS.forEach(endpoint -> matchers.add(builder.matcher(endpoint.method, endpoint.path)));
     }
 
     @Override
@@ -50,7 +59,7 @@ public class ApiAuthenticationFilter extends GenericFilterBean {
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
         String requestURI = httpServletRequest.getRequestURI();
         try {
-            if(API_ENDPOINTS.contains(new ApiKeyEndpoint(httpServletRequest.getMethod(), requestURI))) {
+            if(matchers.stream().anyMatch(matcher -> matcher.matches(httpServletRequest))) {
                 String apiKey = httpServletRequest.getHeader(AUTH_TOKEN_HEADER_NAME);
                 if(apiKey != null) {
                     Authentication authentication = authenticationService.getAuthentication(apiKey, requestURI);
@@ -69,5 +78,5 @@ public class ApiAuthenticationFilter extends GenericFilterBean {
         }
     }
 
-    private record ApiKeyEndpoint(String method, String path){}
+    private record ApiKeyEndpoint(HttpMethod method, String path){}
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
@@ -27,6 +27,8 @@ public class ApiAuthenticationFilter extends GenericFilterBean {
     private static final Collection<String> API_PATHS = List.of(
         GwtTestCaseController.BASE_URL + "/raw");
 
+    private static final String AUTH_TOKEN_HEADER_NAME = "X-API-KEY";
+
     private final AuthenticationService authenticationService;
 
     public ApiAuthenticationFilter(AuthenticationService authenticationService) {
@@ -36,11 +38,15 @@ public class ApiAuthenticationFilter extends GenericFilterBean {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
         throws IOException {
-        String requestURI = ((HttpServletRequest) request).getRequestURI();
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        String requestURI = httpServletRequest.getRequestURI();
         try {
             if(API_PATHS.contains(requestURI)) {
-                Authentication authentication = authenticationService.getAuthentication((HttpServletRequest) request);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                String apiKey = httpServletRequest.getHeader(AUTH_TOKEN_HEADER_NAME);
+                if(apiKey != null) {
+                    Authentication authentication = authenticationService.getAuthentication(apiKey, requestURI);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
             }
             filterChain.doFilter(request, response);
         } catch (Exception e) {

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.security.infra;
+
+import fr.enedis.chutney.scenario.api.GwtTestCaseController;
+import fr.enedis.chutney.security.domain.AuthenticationService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+public class ApiAuthenticationFilter extends GenericFilterBean {
+
+    private static final Collection<String> API_PATHS = List.of(
+        GwtTestCaseController.BASE_URL + "/raw");
+
+    private final AuthenticationService authenticationService;
+
+    public ApiAuthenticationFilter(AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
+        throws IOException {
+        String requestURI = ((HttpServletRequest) request).getRequestURI();
+        try {
+            if(API_PATHS.contains(requestURI)) {
+                Authentication authentication = authenticationService.getAuthentication((HttpServletRequest) request);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            HttpServletResponse httpResponse = (HttpServletResponse) response;
+            httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            httpResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            var printWriter = httpResponse.getWriter();
+            printWriter.print(e.getMessage());
+            printWriter.flush();
+            printWriter.close();
+        }
+    }
+}

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
@@ -34,7 +34,7 @@ public class ApiAuthenticationFilter extends GenericFilterBean {
         new ApiKeyEndpoint("POST", DataSetController.BASE_URL),
         new ApiKeyEndpoint("PUT", DataSetController.BASE_URL),
         new ApiKeyEndpoint("POST", CampaignController.BASE_URL),
-        new ApiKeyEndpoint("GET",EnvironmentController.BASE_URL));
+        new ApiKeyEndpoint("GET", EnvironmentController.BASE_URL));
 
     private static final String AUTH_TOKEN_HEADER_NAME = "X-API-KEY";
 

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
@@ -9,6 +9,7 @@ package fr.enedis.chutney.security.infra;
 
 import fr.enedis.chutney.campaign.api.CampaignController;
 import fr.enedis.chutney.dataset.api.DataSetController;
+import fr.enedis.chutney.environment.api.environment.EnvironmentController;
 import fr.enedis.chutney.scenario.api.GwtTestCaseController;
 import fr.enedis.chutney.security.domain.AuthenticationService;
 import jakarta.servlet.FilterChain;
@@ -29,7 +30,8 @@ public class ApiAuthenticationFilter extends GenericFilterBean {
     private static final Collection<String> API_PATHS = List.of(
         GwtTestCaseController.BASE_URL + "/raw",
         DataSetController.BASE_URL,
-        CampaignController.BASE_URL);
+        CampaignController.BASE_URL,
+        EnvironmentController.BASE_URL);
 
     private static final String AUTH_TOKEN_HEADER_NAME = "X-API-KEY";
 

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
@@ -14,6 +14,7 @@ import fr.enedis.chutney.scenario.api.GwtTestCaseController;
 import fr.enedis.chutney.security.domain.AuthenticationService;
 import fr.enedis.chutney.security.domain.InvalidApiKeyException;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -60,30 +61,32 @@ public class ApiAuthenticationFilter extends GenericFilterBean {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
-        throws IOException {
+        throws IOException, ServletException {
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
         String requestURI = httpServletRequest.getRequestURI();
+        String apiKey = httpServletRequest.getHeader(AUTH_TOKEN_HEADER_NAME);
+        if(apiKey != null) {
+            if(matchers.stream().anyMatch(matcher -> matcher.matches(httpServletRequest))) {
+                apiKeyAuthentication((HttpServletResponse) response, apiKey, requestURI);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void apiKeyAuthentication(HttpServletResponse httpServletResponse, String apiKey, String requestURI) throws IOException {
+        Authentication authentication = null;
         try {
-            String apiKey = httpServletRequest.getHeader(AUTH_TOKEN_HEADER_NAME);
-            if(apiKey != null) {
-                if(matchers.stream().anyMatch(matcher -> matcher.matches(httpServletRequest))) {
-                    Authentication authentication = authenticationService.getAuthentication(apiKey);
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                }
-            }
-            filterChain.doFilter(request, response);
-        } catch (Exception e) {
-            if(e instanceof InvalidApiKeyException) {
-                LOGGER.info("Wrong Api Key for request {}", requestURI);
-            }
-            HttpServletResponse httpResponse = (HttpServletResponse) response;
-            httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            httpResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
-            var printWriter = httpResponse.getWriter();
+            authentication = authenticationService.getAuthentication(apiKey);
+        } catch (InvalidApiKeyException e) {
+            LOGGER.info("Wrong Api Key for request {}", requestURI);
+            httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            httpServletResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            var printWriter = httpServletResponse.getWriter();
             printWriter.print(e.getMessage());
             printWriter.flush();
             printWriter.close();
         }
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
     private record ApiKeyEndpoint(HttpMethod method, String path){}

--- a/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/security/infra/ApiAuthenticationFilter.java
@@ -12,6 +12,7 @@ import fr.enedis.chutney.dataset.api.DataSetController;
 import fr.enedis.chutney.environment.api.environment.EnvironmentController;
 import fr.enedis.chutney.scenario.api.GwtTestCaseController;
 import fr.enedis.chutney.security.domain.AuthenticationService;
+import fr.enedis.chutney.security.domain.InvalidApiKeyException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
@@ -21,6 +22,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -39,6 +42,8 @@ public class ApiAuthenticationFilter extends GenericFilterBean {
         new ApiKeyEndpoint(HttpMethod.PUT, DataSetController.BASE_URL),
         new ApiKeyEndpoint(HttpMethod.POST, CampaignController.BASE_URL),
         new ApiKeyEndpoint(HttpMethod.GET, EnvironmentController.BASE_URL));
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiAuthenticationFilter.class);
 
     private static final String AUTH_TOKEN_HEADER_NAME = "X-API-KEY";
 
@@ -62,12 +67,15 @@ public class ApiAuthenticationFilter extends GenericFilterBean {
             String apiKey = httpServletRequest.getHeader(AUTH_TOKEN_HEADER_NAME);
             if(apiKey != null) {
                 if(matchers.stream().anyMatch(matcher -> matcher.matches(httpServletRequest))) {
-                    Authentication authentication = authenticationService.getAuthentication(apiKey, requestURI);
+                    Authentication authentication = authenticationService.getAuthentication(apiKey);
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
             }
             filterChain.doFilter(request, response);
         } catch (Exception e) {
+            if(e instanceof InvalidApiKeyException) {
+                LOGGER.info("Wrong Api Key for request {}", requestURI);
+            }
             HttpServletResponse httpResponse = (HttpServletResponse) response;
             httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             httpResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
@@ -29,7 +29,7 @@ public class AccessTokenController {
         this.accessTokensService = accessTokensService;
     }
 
-    @PreAuthorize("hasAnyAuthority('ADMIN_ACCESS','CAMPAIGN_WRITE','DATASET_WRITE','SCENARIO_WRITE')")
+    @PreAuthorize("hasAnyAuthority('ADMIN_ACCESS','CAMPAIGN_WRITE','DATASET_WRITE','SCENARIO_WRITE','ENVIRONMENT_READ')")
     @PostMapping(path = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public String createToken(@RequestBody String user) {
         return accessTokensService.createToken(user);

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.tokens.api;
+
+import static fr.enedis.chutney.tokens.api.AccessTokenController.BASE_URL;
+
+import fr.enedis.chutney.tokens.domain.AccessTokensService;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(BASE_URL)
+public class AccessTokenController {
+
+    public static final String BASE_URL = "/api/v1/accesstokens";
+
+    private final AccessTokensService accessTokensService;
+
+    public AccessTokenController(AccessTokensService accessTokensService) {
+        this.accessTokensService = accessTokensService;
+    }
+
+    @PostMapping(path = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public String createToken(@RequestBody String user) {
+        return accessTokensService.createToken(user);
+    }
+}

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
@@ -11,6 +11,8 @@ import static fr.enedis.chutney.tokens.api.AccessTokenController.BASE_URL;
 
 import fr.enedis.chutney.tokens.domain.AccessTokensService;
 import java.security.Principal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,6 +34,6 @@ public class AccessTokenController {
     @PreAuthorize("hasAnyAuthority('ADMIN_ACCESS','CAMPAIGN_WRITE','DATASET_WRITE','SCENARIO_WRITE','ENVIRONMENT_READ')")
     @PostMapping(path = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public String createToken(Principal principal) {
-        return accessTokensService.createToken(principal.getName());
+        return accessTokensService.createToken(principal.getName(), "note", Instant.now().plus(1, ChronoUnit.MONTHS));
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
@@ -32,7 +32,7 @@ public class AccessTokenController {
         this.accessTokensService = accessTokensService;
     }
 
-    @PreAuthorize("hasAnyAuthority('ADMIN_ACCESS','CAMPAIGN_WRITE','DATASET_WRITE','SCENARIO_WRITE','ENVIRONMENT_READ')")
+    @PreAuthorize("hasAnyAuthority('ADMIN_ACCESS','CAMPAIGN_WRITE','DATASET_WRITE','DATASET_READ','SCENARIO_WRITE','SCENARIO_READ','ENVIRONMENT_READ')")
     @PostMapping(path = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public String createToken(Principal principal, @RequestBody AccessTokenDto accessTokenDto) {
         return accessTokensService.createToken(principal.getName(), accessTokenDto.getNote(),

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
@@ -34,6 +34,6 @@ public class AccessTokenController {
     @PreAuthorize("hasAnyAuthority('ADMIN_ACCESS','CAMPAIGN_WRITE','DATASET_WRITE','SCENARIO_WRITE','ENVIRONMENT_READ')")
     @PostMapping(path = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public String createToken(Principal principal) {
-        return accessTokensService.createToken(principal.getName(), "note", Instant.now().plus(1, ChronoUnit.MONTHS));
+        return accessTokensService.createToken(principal.getName(), "note", Instant.now().plus(10, ChronoUnit.DAYS));
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
@@ -10,10 +10,10 @@ package fr.enedis.chutney.tokens.api;
 import static fr.enedis.chutney.tokens.api.AccessTokenController.BASE_URL;
 
 import fr.enedis.chutney.tokens.domain.AccessTokensService;
+import java.security.Principal;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,7 +31,7 @@ public class AccessTokenController {
 
     @PreAuthorize("hasAnyAuthority('ADMIN_ACCESS','CAMPAIGN_WRITE','DATASET_WRITE','SCENARIO_WRITE','ENVIRONMENT_READ')")
     @PostMapping(path = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public String createToken(@RequestBody String user) {
-        return accessTokensService.createToken(user);
+    public String createToken(Principal principal) {
+        return accessTokensService.createToken(principal.getName());
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
@@ -11,6 +11,7 @@ import static fr.enedis.chutney.tokens.api.AccessTokenController.BASE_URL;
 
 import fr.enedis.chutney.tokens.api.dto.AccessTokenDto;
 import fr.enedis.chutney.tokens.domain.AccessTokensService;
+import jakarta.validation.Valid;
 import java.security.Principal;
 import java.time.ZoneId;
 import org.springframework.http.MediaType;
@@ -34,7 +35,7 @@ public class AccessTokenController {
 
     @PreAuthorize("hasAnyAuthority('ADMIN_ACCESS','CAMPAIGN_WRITE','DATASET_WRITE','DATASET_READ','SCENARIO_WRITE','SCENARIO_READ','ENVIRONMENT_READ')")
     @PostMapping(path = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public String createToken(Principal principal, @RequestBody AccessTokenDto accessTokenDto) {
+    public String createToken(Principal principal, @Valid @RequestBody AccessTokenDto accessTokenDto) {
         return accessTokensService.createToken(principal.getName(), accessTokenDto.getNote(),
             accessTokenDto.getExpiresAt().atStartOfDay(ZoneId.systemDefault()).toInstant()
         );

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
@@ -9,13 +9,14 @@ package fr.enedis.chutney.tokens.api;
 
 import static fr.enedis.chutney.tokens.api.AccessTokenController.BASE_URL;
 
+import fr.enedis.chutney.tokens.api.dto.AccessTokenDto;
 import fr.enedis.chutney.tokens.domain.AccessTokensService;
 import java.security.Principal;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
+import java.time.ZoneId;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,7 +34,9 @@ public class AccessTokenController {
 
     @PreAuthorize("hasAnyAuthority('ADMIN_ACCESS','CAMPAIGN_WRITE','DATASET_WRITE','SCENARIO_WRITE','ENVIRONMENT_READ')")
     @PostMapping(path = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public String createToken(Principal principal) {
-        return accessTokensService.createToken(principal.getName(), "note", Instant.now().plus(10, ChronoUnit.DAYS));
+    public String createToken(Principal principal, @RequestBody AccessTokenDto accessTokenDto) {
+        return accessTokensService.createToken(principal.getName(), accessTokenDto.getNote(),
+            accessTokenDto.getExpiresAt().atStartOfDay(ZoneId.systemDefault()).toInstant()
+        );
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
@@ -11,6 +11,7 @@ import static fr.enedis.chutney.tokens.api.AccessTokenController.BASE_URL;
 
 import fr.enedis.chutney.tokens.domain.AccessTokensService;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,6 +29,7 @@ public class AccessTokenController {
         this.accessTokensService = accessTokensService;
     }
 
+    @PreAuthorize("hasAnyAuthority('ADMIN_ACCESS','CAMPAIGN_WRITE','DATASET_WRITE','SCENARIO_WRITE')")
     @PostMapping(path = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public String createToken(@RequestBody String user) {
         return accessTokensService.createToken(user);

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
@@ -34,7 +34,7 @@ public class AccessTokenController {
     }
 
     @PreAuthorize("hasAnyAuthority('ADMIN_ACCESS','CAMPAIGN_WRITE','DATASET_WRITE','DATASET_READ','SCENARIO_WRITE','SCENARIO_READ','ENVIRONMENT_READ')")
-    @PostMapping(path = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(path = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.TEXT_PLAIN_VALUE)
     public String createToken(Principal principal, @Valid @RequestBody AccessTokenDto accessTokenDto) {
         return accessTokensService.createToken(principal.getName(), accessTokenDto.getNote(),
             accessTokenDto.getExpiresAt() != null ?

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/AccessTokenController.java
@@ -37,7 +37,8 @@ public class AccessTokenController {
     @PostMapping(path = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public String createToken(Principal principal, @Valid @RequestBody AccessTokenDto accessTokenDto) {
         return accessTokensService.createToken(principal.getName(), accessTokenDto.getNote(),
-            accessTokenDto.getExpiresAt().atStartOfDay(ZoneId.systemDefault()).toInstant()
+            accessTokenDto.getExpiresAt() != null ?
+                accessTokenDto.getExpiresAt().atStartOfDay(ZoneId.systemDefault()).toInstant() : null
         );
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/dto/AccessTokenDto.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/dto/AccessTokenDto.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.tokens.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.LocalDate;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AccessTokenDto {
+
+    private String note;
+    private LocalDate expiresAt;
+
+    @JsonCreator
+    public AccessTokenDto() {
+    }
+
+    public AccessTokenDto(String note, LocalDate expiresAt) {
+        this.note = note;
+        this.expiresAt = expiresAt;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public LocalDate getExpiresAt() {
+        return expiresAt;
+    }
+}

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/dto/AccessTokenDto.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/dto/AccessTokenDto.java
@@ -9,12 +9,17 @@ package fr.enedis.chutney.tokens.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AccessTokenDto {
 
     private String note;
+
+    @JsonProperty(required = true)
+    @NotNull
     private LocalDate expiresAt;
 
     @JsonCreator

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/dto/AccessTokenDto.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/dto/AccessTokenDto.java
@@ -16,6 +16,8 @@ import java.time.LocalDate;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AccessTokenDto {
 
+    @JsonProperty(required = true)
+    @NotNull
     private String note;
 
     @JsonProperty(required = true)

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/dto/AccessTokenDto.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/api/dto/AccessTokenDto.java
@@ -20,8 +20,6 @@ public class AccessTokenDto {
     @NotNull
     private String note;
 
-    @JsonProperty(required = true)
-    @NotNull
     private LocalDate expiresAt;
 
     @JsonCreator

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessToken.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessToken.java
@@ -8,17 +8,15 @@
 package fr.enedis.chutney.tokens.domain;
 
 import java.time.Instant;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 public record AccessToken(String user, String note, String hash, Instant expiresAt) {
 
-    public static AccessToken create(String user, String token, String note, Instant expiresAt) {
-        var hash = new BCryptPasswordEncoder().encode(token);
+    public static AccessToken create(String user, String token, String note, Instant expiresAt, AccessTokenEncoder encoder) {
+        var hash = encoder.encode(token);
         return new AccessToken(user, note, hash, expiresAt);
     }
 
-    public boolean matchTokenAndIsValid(String token) {
-        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+    public boolean matchTokenAndIsValid(String token, AccessTokenEncoder encoder) {
         return encoder.matches(token, this.hash) && this.expiresAt.isAfter(Instant.now());
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessToken.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessToken.java
@@ -7,5 +7,7 @@
 
 package fr.enedis.chutney.tokens.domain;
 
-public record AccessToken(String id, String user, String hashedToken) {
+import java.time.Instant;
+
+public record AccessToken(String id, String user, String hashedToken, Instant createdAt) {
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessToken.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessToken.java
@@ -8,6 +8,17 @@
 package fr.enedis.chutney.tokens.domain;
 
 import java.time.Instant;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 public record AccessToken(String user, String note, String hash, Instant expiresAt) {
+
+    public static AccessToken create(String user, String token, String note, Instant expiresAt) {
+        var hash = new BCryptPasswordEncoder().encode(token);
+        return new AccessToken(user, note, hash, expiresAt);
+    }
+
+    public boolean matchTokenAndIsValid(String token) {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        return encoder.matches(token, this.hash) && this.expiresAt.isAfter(Instant.now());
+    }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessToken.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessToken.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.tokens.domain;
+
+public record AccessToken(String id, String user, String hashedToken) {
+}

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessToken.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessToken.java
@@ -9,5 +9,5 @@ package fr.enedis.chutney.tokens.domain;
 
 import java.time.Instant;
 
-public record AccessToken(String id, String user, String hashedToken, Instant createdAt) {
+public record AccessToken(String user, String note, String hash, Instant expiresAt) {
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessToken.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessToken.java
@@ -16,6 +16,7 @@ public record AccessToken(String user, String note, String hash, Instant expires
     }
 
     public boolean matchTokenAndIsValid(String token, AccessTokenEncoder encoder) {
-        return encoder.matches(token, this.hash) && this.expiresAt.isAfter(Instant.now());
+        return encoder.matches(token, this.hash)
+            && (this.expiresAt == null || this.expiresAt.isAfter(Instant.now()));
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessToken.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessToken.java
@@ -11,8 +11,7 @@ import java.time.Instant;
 
 public record AccessToken(String user, String note, String hash, Instant expiresAt) {
 
-    public static AccessToken create(String user, String token, String note, Instant expiresAt, AccessTokenEncoder encoder) {
-        var hash = encoder.encode(token);
+    public static AccessToken create(String user, String note, Instant expiresAt, String hash) {
         return new AccessToken(user, note, hash, expiresAt);
     }
 

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokenEncoder.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokenEncoder.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.tokens.domain;
+
+public interface AccessTokenEncoder {
+
+    String encode(CharSequence rawPassword);
+    boolean matches(CharSequence rawPassword, String encodedPassword);
+}

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokenEncoder.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokenEncoder.java
@@ -9,6 +9,6 @@ package fr.enedis.chutney.tokens.domain;
 
 public interface AccessTokenEncoder {
 
-    String encode(CharSequence token);
-    boolean matches(CharSequence token, String hash);
+    String encode(String token);
+    boolean matches(String token, String hash);
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokenEncoder.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokenEncoder.java
@@ -9,6 +9,6 @@ package fr.enedis.chutney.tokens.domain;
 
 public interface AccessTokenEncoder {
 
-    String encode(CharSequence rawPassword);
-    boolean matches(CharSequence rawPassword, String encodedPassword);
+    String encode(CharSequence token);
+    boolean matches(CharSequence token, String hash);
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensRepository.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensRepository.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.tokens.domain;
+
+public interface AccessTokensRepository {
+
+    void createToken();
+}

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensRepository.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensRepository.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 
 public interface AccessTokensRepository {
 
-    void createToken();
+    void createToken(AccessToken accessToken);
 
     Collection<String> getTokens();
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensRepository.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensRepository.java
@@ -7,7 +7,11 @@
 
 package fr.enedis.chutney.tokens.domain;
 
+import java.util.Collection;
+
 public interface AccessTokensRepository {
 
     void createToken();
+
+    Collection<String> getTokens();
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensRepository.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensRepository.java
@@ -13,5 +13,5 @@ public interface AccessTokensRepository {
 
     void createToken(AccessToken accessToken);
 
-    Collection<String> getTokens();
+    Collection<AccessToken> getTokens();
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensRepository.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensRepository.java
@@ -7,11 +7,11 @@
 
 package fr.enedis.chutney.tokens.domain;
 
-import java.util.Collection;
+import java.util.List;
 
 public interface AccessTokensRepository {
 
     void createToken(AccessToken accessToken);
 
-    Collection<AccessToken> getTokens();
+    List<AccessToken> getTokens();
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -7,6 +7,8 @@
 
 package fr.enedis.chutney.tokens.domain;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.UUID;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -22,15 +24,18 @@ public class AccessTokensService {
     public String createToken(String user) {
         String rawKey = UUID.randomUUID().toString().replace("-", "");
         String token = new BCryptPasswordEncoder().encode(rawKey);
-        accessTokensRepository.createToken(new AccessToken(UUID.randomUUID().toString(), user, token));
+        accessTokensRepository.createToken(new AccessToken(UUID.randomUUID().toString(), user, token, Instant.now()));
         return token;
     }
 
     public boolean matchToken(String token, String user) {
+        var threeMonthsAgo = Instant.now().minus(90, ChronoUnit.DAYS);
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
         Collection<AccessToken> tokens = accessTokensRepository.getTokens();
         for (var repoToken : tokens) {
-            if (encoder.matches(token, repoToken.hashedToken()) && repoToken.user().equals(user)) {
+            if (encoder.matches(token, repoToken.hashedToken())
+                && repoToken.user().equals(user)
+                && repoToken.createdAt().isAfter(threeMonthsAgo)) {
                 return true;
             }
         }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -27,7 +27,7 @@ public class AccessTokensService {
     public String createToken(String user) {
         String token = UUID.randomUUID().toString().replace("-", "");
         String hash = new BCryptPasswordEncoder().encode(token);
-        accessTokensRepository.createToken(new AccessToken(UUID.randomUUID().toString(), user, hash, Instant.now()));
+        accessTokensRepository.createToken(new AccessToken(user, "note", hash, Instant.now().plus(1, ChronoUnit.DAYS)));
         return token;
     }
 
@@ -36,8 +36,8 @@ public class AccessTokensService {
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
         Collection<AccessToken> tokens = accessTokensRepository.getTokens();
         for (var repoToken : tokens) {
-            if (encoder.matches(token, repoToken.hashedToken())
-                && repoToken.createdAt().isAfter(threeMonthsAgo)) {
+            if (encoder.matches(token, repoToken.hash())
+                && repoToken.expiresAt().isAfter(Instant.now())) {
                 return Optional.of(repoToken);
             }
         }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -30,13 +30,12 @@ public class AccessTokensService {
         return token;
     }
 
-    public boolean matchToken(String token, String user) {
+    public boolean matchToken(String token) {
         var threeMonthsAgo = Instant.now().minus(90, ChronoUnit.DAYS);
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
         Collection<AccessToken> tokens = accessTokensRepository.getTokens();
         for (var repoToken : tokens) {
             if (encoder.matches(token, repoToken.hashedToken())
-                && repoToken.user().equals(user)
                 && repoToken.createdAt().isAfter(threeMonthsAgo)) {
                 return true;
             }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.tokens.domain;
+
+import java.util.UUID;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class AccessTokensService {
+
+    private final AccessTokensRepository accessTokensRepository;
+
+    public AccessTokensService(AccessTokensRepository accessTokensRepository) {
+        this.accessTokensRepository = accessTokensRepository;
+    }
+
+    public String createToken(String user) {
+        String rawKey = UUID.randomUUID().toString().replace("-", "");
+        String token = new BCryptPasswordEncoder().encode(rawKey);
+        accessTokensRepository.createToken();
+        return token;
+    }
+}

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -12,7 +12,9 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.UUID;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
 
+@Component
 public class AccessTokensService {
 
     private final AccessTokensRepository accessTokensRepository;

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -8,11 +8,9 @@
 package fr.enedis.chutney.tokens.domain;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -24,20 +22,16 @@ public class AccessTokensService {
         this.accessTokensRepository = accessTokensRepository;
     }
 
-    public String createToken(String user) {
+    public String createToken(String user, String note, Instant expiresAt) {
         String token = UUID.randomUUID().toString().replace("-", "");
-        String hash = new BCryptPasswordEncoder().encode(token);
-        accessTokensRepository.createToken(new AccessToken(user, "note", hash, Instant.now().plus(1, ChronoUnit.DAYS)));
+        accessTokensRepository.createToken(AccessToken.create(user, note, token, expiresAt));
         return token;
     }
 
     public Optional<AccessToken> userFromToken(String token) {
-        var threeMonthsAgo = Instant.now().minus(90, ChronoUnit.DAYS);
-        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
         Collection<AccessToken> tokens = accessTokensRepository.getTokens();
         for (var repoToken : tokens) {
-            if (encoder.matches(token, repoToken.hash())
-                && repoToken.expiresAt().isAfter(Instant.now())) {
+            if (repoToken.matchTokenAndIsValid(token)) {
                 return Optional.of(repoToken);
             }
         }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -7,6 +7,7 @@
 
 package fr.enedis.chutney.tokens.domain;
 
+import java.util.Collection;
 import java.util.UUID;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
@@ -23,5 +24,16 @@ public class AccessTokensService {
         String token = new BCryptPasswordEncoder().encode(rawKey);
         accessTokensRepository.createToken();
         return token;
+    }
+
+    public boolean matchToken(String token) {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        Collection<String> tokens = accessTokensRepository.getTokens();
+        for (var repoToken : tokens) {
+            if (encoder.matches(token, repoToken)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -13,9 +13,9 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 public class AccessTokensService {
 
     private final AccessTokensRepository accessTokensRepository;
@@ -25,10 +25,10 @@ public class AccessTokensService {
     }
 
     public String createToken(String user) {
-        String rawKey = UUID.randomUUID().toString().replace("-", "");
-        String token = new BCryptPasswordEncoder().encode(rawKey);
-        accessTokensRepository.createToken(new AccessToken(UUID.randomUUID().toString(), user, token, Instant.now()));
-        return rawKey;
+        String token = UUID.randomUUID().toString().replace("-", "");
+        String hash = new BCryptPasswordEncoder().encode(token);
+        accessTokensRepository.createToken(new AccessToken(UUID.randomUUID().toString(), user, hash, Instant.now()));
+        return token;
     }
 
     public Optional<AccessToken> userFromToken(String token) {

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -24,7 +24,7 @@ public class AccessTokensService {
 
     public String createToken(String user, String note, Instant expiresAt) {
         String token = UUID.randomUUID().toString().replace("-", "");
-        accessTokensRepository.createToken(AccessToken.create(user, note, token, expiresAt));
+        accessTokensRepository.createToken(AccessToken.create(user, token, note, expiresAt));
         return token;
     }
 

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -31,7 +31,7 @@ public class AccessTokensService {
         return token;
     }
 
-    public Optional<AccessToken> userFromToken(String token) {
+    public Optional<AccessToken> accessTokenFromRaw(String token) {
         Collection<AccessToken> tokens = accessTokensRepository.getTokens();
         for (var repoToken : tokens) {
             if (repoToken.matchTokenAndIsValid(token, accessTokenEncoder)) {

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -31,14 +31,14 @@ public class AccessTokensService {
         return rawKey;
     }
 
-    public Optional<String> userFromToken(String token) {
+    public Optional<AccessToken> userFromToken(String token) {
         var threeMonthsAgo = Instant.now().minus(90, ChronoUnit.DAYS);
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
         Collection<AccessToken> tokens = accessTokensRepository.getTokens();
         for (var repoToken : tokens) {
             if (encoder.matches(token, repoToken.hashedToken())
                 && repoToken.createdAt().isAfter(threeMonthsAgo)) {
-                return Optional.of(repoToken.user());
+                return Optional.of(repoToken);
             }
         }
         return Optional.empty();

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -10,6 +10,7 @@ package fr.enedis.chutney.tokens.domain;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -30,16 +31,16 @@ public class AccessTokensService {
         return rawKey;
     }
 
-    public boolean matchToken(String token) {
+    public Optional<String> userFromToken(String token) {
         var threeMonthsAgo = Instant.now().minus(90, ChronoUnit.DAYS);
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
         Collection<AccessToken> tokens = accessTokensRepository.getTokens();
         for (var repoToken : tokens) {
             if (encoder.matches(token, repoToken.hashedToken())
                 && repoToken.createdAt().isAfter(threeMonthsAgo)) {
-                return true;
+                return Optional.of(repoToken.user());
             }
         }
-        return false;
+        return Optional.empty();
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -22,11 +22,11 @@ public class AccessTokensService {
     public String createToken(String user) {
         String rawKey = UUID.randomUUID().toString().replace("-", "");
         String token = new BCryptPasswordEncoder().encode(rawKey);
-        accessTokensRepository.createToken();
+        accessTokensRepository.createToken(new AccessToken(UUID.randomUUID().toString(), user, token));
         return token;
     }
 
-    public boolean matchToken(String token) {
+    public boolean matchToken(String token, String user) {
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
         Collection<String> tokens = accessTokensRepository.getTokens();
         for (var repoToken : tokens) {

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -28,9 +28,9 @@ public class AccessTokensService {
 
     public boolean matchToken(String token, String user) {
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
-        Collection<String> tokens = accessTokensRepository.getTokens();
+        Collection<AccessToken> tokens = accessTokensRepository.getTokens();
         for (var repoToken : tokens) {
-            if (encoder.matches(token, repoToken)) {
+            if (encoder.matches(token, repoToken.hashedToken()) && repoToken.user().equals(user)) {
                 return true;
             }
         }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -17,21 +17,24 @@ import org.springframework.stereotype.Service;
 public class AccessTokensService {
 
     private final AccessTokensRepository accessTokensRepository;
+    private final AccessTokenEncoder accessTokenEncoder;
 
-    public AccessTokensService(AccessTokensRepository accessTokensRepository) {
+    public AccessTokensService(AccessTokensRepository accessTokensRepository,
+                               AccessTokenEncoder accessTokenEncoder) {
         this.accessTokensRepository = accessTokensRepository;
+        this.accessTokenEncoder = accessTokenEncoder;
     }
 
     public String createToken(String user, String note, Instant expiresAt) {
         String token = UUID.randomUUID().toString().replace("-", "");
-        accessTokensRepository.createToken(AccessToken.create(user, token, note, expiresAt));
+        accessTokensRepository.createToken(AccessToken.create(user, token, note, expiresAt, accessTokenEncoder));
         return token;
     }
 
     public Optional<AccessToken> userFromToken(String token) {
         Collection<AccessToken> tokens = accessTokensRepository.getTokens();
         for (var repoToken : tokens) {
-            if (repoToken.matchTokenAndIsValid(token)) {
+            if (repoToken.matchTokenAndIsValid(token, accessTokenEncoder)) {
                 return Optional.of(repoToken);
             }
         }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -27,7 +27,7 @@ public class AccessTokensService {
         String rawKey = UUID.randomUUID().toString().replace("-", "");
         String token = new BCryptPasswordEncoder().encode(rawKey);
         accessTokensRepository.createToken(new AccessToken(UUID.randomUUID().toString(), user, token, Instant.now()));
-        return token;
+        return rawKey;
     }
 
     public boolean matchToken(String token) {

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/domain/AccessTokensService.java
@@ -8,7 +8,7 @@
 package fr.enedis.chutney.tokens.domain;
 
 import java.time.Instant;
-import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -26,13 +26,14 @@ public class AccessTokensService {
     }
 
     public String createToken(String user, String note, Instant expiresAt) {
-        String token = UUID.randomUUID().toString().replace("-", "");
-        accessTokensRepository.createToken(AccessToken.create(user, token, note, expiresAt, accessTokenEncoder));
+        var token = UUID.randomUUID().toString().replace("-", "");
+        var hash = accessTokenEncoder.encode(token);
+        accessTokensRepository.createToken(AccessToken.create(user, note, expiresAt, hash));
         return token;
     }
 
     public Optional<AccessToken> accessTokenFromRaw(String token) {
-        Collection<AccessToken> tokens = accessTokensRepository.getTokens();
+        List<AccessToken> tokens = accessTokensRepository.getTokens();
         for (var repoToken : tokens) {
             if (repoToken.matchTokenAndIsValid(token, accessTokenEncoder)) {
                 return Optional.of(repoToken);

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/AccessTokenJpaRepository.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/AccessTokenJpaRepository.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.tokens.infra;
+
+import fr.enedis.chutney.tokens.infra.jpa.AccessTokenEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccessTokenJpaRepository extends JpaRepository<AccessTokenEntity,Long> {
+}

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/BCryptAccessTokenEncoder.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/BCryptAccessTokenEncoder.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.tokens.infra;
+
+import fr.enedis.chutney.tokens.domain.AccessTokenEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BCryptAccessTokenEncoder implements AccessTokenEncoder {
+
+    private final BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        return bCryptPasswordEncoder.encode(rawPassword);
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        return bCryptPasswordEncoder.matches(rawPassword, encodedPassword);
+    }
+}

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/BCryptAccessTokenEncoder.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/BCryptAccessTokenEncoder.java
@@ -17,12 +17,12 @@ public class BCryptAccessTokenEncoder implements AccessTokenEncoder {
     private final BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
 
     @Override
-    public String encode(CharSequence token) {
+    public String encode(String token) {
         return bCryptPasswordEncoder.encode(token);
     }
 
     @Override
-    public boolean matches(CharSequence token, String hash) {
+    public boolean matches(String token, String hash) {
         return bCryptPasswordEncoder.matches(token, hash);
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/BCryptAccessTokenEncoder.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/BCryptAccessTokenEncoder.java
@@ -17,12 +17,12 @@ public class BCryptAccessTokenEncoder implements AccessTokenEncoder {
     private final BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
 
     @Override
-    public String encode(CharSequence rawPassword) {
-        return bCryptPasswordEncoder.encode(rawPassword);
+    public String encode(CharSequence token) {
+        return bCryptPasswordEncoder.encode(token);
     }
 
     @Override
-    public boolean matches(CharSequence rawPassword, String encodedPassword) {
-        return bCryptPasswordEncoder.matches(rawPassword, encodedPassword);
+    public boolean matches(CharSequence token, String hash) {
+        return bCryptPasswordEncoder.matches(token, hash);
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepository.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepository.java
@@ -27,13 +27,14 @@ public class DatabaseAccessTokensDBRepository implements AccessTokensRepository 
 
     @Override
     public void createToken(AccessToken accessToken) {
-        accessTokenJpaRepository.save(new AccessTokenEntity(null,
-            accessToken.user(), accessToken.hashedToken(), accessToken.createdAt().toEpochMilli()));
+        accessTokenJpaRepository.save(new AccessTokenEntity(
+            accessToken.user(), accessToken.note(), accessToken.hash(), accessToken.expiresAt().toEpochMilli()));
     }
 
     @Override
     public Collection<AccessToken> getTokens() {
-        return accessTokenJpaRepository.findAll().stream().map(accessTokenEntity -> new AccessToken(accessTokenEntity.getId().toString(),
-            accessTokenEntity.getOwner(), accessTokenEntity.getHashedToken(), Instant.ofEpochMilli(accessTokenEntity.getCreatedAt()))).toList();
+        return accessTokenJpaRepository.findAll().stream().map(accessTokenEntity ->
+            new AccessToken(accessTokenEntity.getOwner(), accessTokenEntity.getNote(),
+                accessTokenEntity.getHash(), Instant.ofEpochMilli(accessTokenEntity.getExpiresAt()))).toList();
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepository.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepository.java
@@ -26,6 +26,7 @@ public class DatabaseAccessTokensDBRepository implements AccessTokensRepository 
     }
 
     @Override
+    @Transactional
     public void createToken(AccessToken accessToken) {
         accessTokenJpaRepository.save(new AccessTokenEntity(
             accessToken.user(), accessToken.note(), accessToken.hash(), accessToken.expiresAt().toEpochMilli()));

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepository.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepository.java
@@ -34,7 +34,7 @@ public class DatabaseAccessTokensDBRepository implements AccessTokensRepository 
     @Override
     public Collection<AccessToken> getTokens() {
         return accessTokenJpaRepository.findAll().stream().map(accessTokenEntity ->
-            new AccessToken(accessTokenEntity.getOwner(), accessTokenEntity.getNote(),
-                accessTokenEntity.getHash(), Instant.ofEpochMilli(accessTokenEntity.getExpiresAt()))).toList();
+            new AccessToken(accessTokenEntity.getOwner(), accessTokenEntity.getNote(), accessTokenEntity.getHash(),
+                Instant.ofEpochMilli(accessTokenEntity.getExpiresAt()))).toList();
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepository.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepository.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.tokens.infra;
+
+import fr.enedis.chutney.tokens.domain.AccessToken;
+import fr.enedis.chutney.tokens.domain.AccessTokensRepository;
+import fr.enedis.chutney.tokens.infra.jpa.AccessTokenEntity;
+import java.time.Instant;
+import java.util.Collection;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional(readOnly = true)
+public class DatabaseAccessTokensDBRepository implements AccessTokensRepository {
+
+    private final AccessTokenJpaRepository accessTokenJpaRepository;
+
+    public DatabaseAccessTokensDBRepository(AccessTokenJpaRepository accessTokenJpaRepository) {
+        this.accessTokenJpaRepository = accessTokenJpaRepository;
+    }
+
+    @Override
+    public void createToken(AccessToken accessToken) {
+        accessTokenJpaRepository.save(new AccessTokenEntity(null,
+            accessToken.user(), accessToken.hashedToken(), accessToken.createdAt().toEpochMilli()));
+    }
+
+    @Override
+    public Collection<AccessToken> getTokens() {
+        return accessTokenJpaRepository.findAll().stream().map(accessTokenEntity -> new AccessToken(accessTokenEntity.getId().toString(),
+            accessTokenEntity.getOwner(), accessTokenEntity.getHashedToken(), Instant.ofEpochMilli(accessTokenEntity.getCreatedAt()))).toList();
+    }
+}

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepository.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepository.java
@@ -11,7 +11,7 @@ import fr.enedis.chutney.tokens.domain.AccessToken;
 import fr.enedis.chutney.tokens.domain.AccessTokensRepository;
 import fr.enedis.chutney.tokens.infra.jpa.AccessTokenEntity;
 import java.time.Instant;
-import java.util.Collection;
+import java.util.List;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,7 +33,7 @@ public class DatabaseAccessTokensDBRepository implements AccessTokensRepository 
     }
 
     @Override
-    public Collection<AccessToken> getTokens() {
+    public List<AccessToken> getTokens() {
         return accessTokenJpaRepository.findAll().stream().map(accessTokenEntity ->
             new AccessToken(accessTokenEntity.getOwner(), accessTokenEntity.getNote(), accessTokenEntity.getHash(),
                 Instant.ofEpochMilli(accessTokenEntity.getExpiresAt()))).toList();

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepository.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepository.java
@@ -29,13 +29,14 @@ public class DatabaseAccessTokensDBRepository implements AccessTokensRepository 
     @Transactional
     public void createToken(AccessToken accessToken) {
         accessTokenJpaRepository.save(new AccessTokenEntity(
-            accessToken.user(), accessToken.note(), accessToken.hash(), accessToken.expiresAt().toEpochMilli()));
+            accessToken.user(), accessToken.note(), accessToken.hash(),
+            accessToken.expiresAt() != null ? accessToken.expiresAt().toEpochMilli() : null));
     }
 
     @Override
     public List<AccessToken> getTokens() {
         return accessTokenJpaRepository.findAll().stream().map(accessTokenEntity ->
             new AccessToken(accessTokenEntity.getOwner(), accessTokenEntity.getNote(), accessTokenEntity.getHash(),
-                Instant.ofEpochMilli(accessTokenEntity.getExpiresAt()))).toList();
+                accessTokenEntity.getExpiresAt() != null ? Instant.ofEpochMilli(accessTokenEntity.getExpiresAt()) : null)).toList();
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/jpa/AccessTokenEntity.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/jpa/AccessTokenEntity.java
@@ -25,35 +25,42 @@ public class AccessTokenEntity implements Serializable {
     @Column(name = "OWNER", updatable = false)
     private String owner;
 
-    @Column(name = "HASHED_TOKEN", updatable = false)
-    private String hashedToken;
+    @Column(name = "NOTE", updatable = false)
+    private String note;
 
-    @Column(name = "CREATED_AT", updatable = false)
-    private Long createdAt;
+    @Column(name = "HASH", updatable = false)
+    private String hash;
+
+    @Column(name = "EXPIRES_AT", updatable = false)
+    private Long expiresAt;
 
     public AccessTokenEntity() {
     }
 
-    public AccessTokenEntity(Long id, String owner, String hashedToken, Long createdAt) {
-        this.id = id;
+    public AccessTokenEntity(String owner, String note, String hash, Long expiresAt) {
         this.owner = owner;
-        this.hashedToken = hashedToken;
-        this.createdAt = createdAt;
+        this.note = note;
+        this.hash = hash;
+        this.expiresAt = expiresAt;
     }
 
     public Long getId() {
         return id;
     }
 
+    public String getNote() {
+        return note;
+    }
+
     public String getOwner() {
         return owner;
     }
 
-    public String getHashedToken() {
-        return hashedToken;
+    public String getHash() {
+        return hash;
     }
 
-    public Long getCreatedAt() {
-        return createdAt;
+    public Long getExpiresAt() {
+        return expiresAt;
     }
 }

--- a/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/jpa/AccessTokenEntity.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/tokens/infra/jpa/AccessTokenEntity.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.tokens.infra.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.io.Serializable;
+
+@Entity(name = "ACCESS_TOKEN")
+public class AccessTokenEntity implements Serializable {
+
+    @Id
+    @Column(name = "ID")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "OWNER", updatable = false)
+    private String owner;
+
+    @Column(name = "HASHED_TOKEN", updatable = false)
+    private String hashedToken;
+
+    @Column(name = "CREATED_AT", updatable = false)
+    private Long createdAt;
+
+    public AccessTokenEntity() {
+    }
+
+    public AccessTokenEntity(Long id, String owner, String hashedToken, Long createdAt) {
+        this.id = id;
+        this.owner = owner;
+        this.hashedToken = hashedToken;
+        this.createdAt = createdAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public String getHashedToken() {
+        return hashedToken;
+    }
+
+    public Long getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/chutney/server/src/main/resources/changelog/db.changelog-master.xml
+++ b/chutney/server/src/main/resources/changelog/db.changelog-master.xml
@@ -1125,7 +1125,7 @@
             <column name="NOTE" type="VARCHAR(300)">
                 <constraints nullable="false"/>
             </column>
-            <column name="HASH" type="VARCHAR(300)">
+            <column name="HASH" type="TEXT">
                 <constraints nullable="false"/>
             </column>
             <column name="EXPIRES_AT" type="NUMBER">

--- a/chutney/server/src/main/resources/changelog/db.changelog-master.xml
+++ b/chutney/server/src/main/resources/changelog/db.changelog-master.xml
@@ -1122,10 +1122,13 @@
             <column name="OWNER" type="VARCHAR(300)">
                 <constraints nullable="false"/>
             </column>
-            <column name="HASHED_TOKEN" type="VARCHAR(300)">
+            <column name="NOTE" type="VARCHAR(300)">
                 <constraints nullable="false"/>
             </column>
-            <column name="CREATED_AT" type="NUMBER">
+            <column name="HASH" type="VARCHAR(300)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="EXPIRES_AT" type="NUMBER">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/chutney/server/src/main/resources/changelog/db.changelog-master.xml
+++ b/chutney/server/src/main/resources/changelog/db.changelog-master.xml
@@ -1122,9 +1122,7 @@
             <column name="OWNER" type="VARCHAR(300)">
                 <constraints nullable="false"/>
             </column>
-            <column name="NOTE" type="VARCHAR(300)">
-                <constraints nullable="false"/>
-            </column>
+            <column name="NOTE" type="VARCHAR(300)"/>
             <column name="HASH" type="TEXT">
                 <constraints nullable="false"/>
             </column>

--- a/chutney/server/src/main/resources/changelog/db.changelog-master.xml
+++ b/chutney/server/src/main/resources/changelog/db.changelog-master.xml
@@ -1114,4 +1114,20 @@
             <column name="SCENARIO_ID"/>
         </createIndex>
     </changeSet>
+    <changeSet id="create-access-token-table" author="ICG">
+        <createTable tableName="ACCESS_TOKEN">
+            <column name="ID" type="INTEGER" autoIncrement="true">
+                <constraints unique="true" nullable="false" primaryKey="true"/>
+            </column>
+            <column name="OWNER" type="VARCHAR(300)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="HASHED_TOKEN" type="VARCHAR(300)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CREATED_AT" type="NUMBER">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
 </databaseChangeLog>

--- a/chutney/server/src/main/resources/changelog/db.changelog-master.xml
+++ b/chutney/server/src/main/resources/changelog/db.changelog-master.xml
@@ -1122,13 +1122,13 @@
             <column name="OWNER" type="VARCHAR(300)">
                 <constraints nullable="false"/>
             </column>
-            <column name="NOTE" type="VARCHAR(300)"/>
+            <column name="NOTE" type="VARCHAR(300)">
+                <constraints nullable="false"/>
+            </column>
             <column name="HASH" type="TEXT">
                 <constraints nullable="false"/>
             </column>
-            <column name="EXPIRES_AT" type="NUMBER">
-                <constraints nullable="false"/>
-            </column>
+            <column name="EXPIRES_AT" type="NUMBER"/>
         </createTable>
     </changeSet>
 </databaseChangeLog>

--- a/chutney/server/src/test/java/blackbox/SecuredControllerSpringBootIntegrationTest.java
+++ b/chutney/server/src/test/java/blackbox/SecuredControllerSpringBootIntegrationTest.java
@@ -71,6 +71,7 @@ import fr.enedis.chutney.security.infra.jwt.JwtUtil;
 import fr.enedis.chutney.server.core.domain.security.Role;
 import fr.enedis.chutney.server.core.domain.security.User;
 import fr.enedis.chutney.server.core.domain.security.UserRoles;
+import fr.enedis.chutney.tokens.api.AccessTokenController;
 import fr.enedis.chutney.tools.file.FileUtils;
 import java.io.File;
 import java.util.List;
@@ -296,6 +297,8 @@ public class SecuredControllerSpringBootIntegrationTest {
 
             // Must be at the end because the network configuration is in wrong state, why ??
             {POST, NodeNetworkController.WRAP_UP_URL, ADMIN_ACCESS.name(), "{\"agentsGraph\":{\"agents\":[]},\"networkConfiguration\":{\"creationDate\":\"2021-09-06T10:08:36.569227Z\",\"agentNetworkConfiguration\":[],\"environmentsConfiguration\":[]}}", OK},
+
+            {POST, AccessTokenController.BASE_URL, ADMIN_ACCESS.name(), "{\"user\":\"username\"}", OK},
         };
     }
 

--- a/chutney/server/src/test/java/blackbox/SecuredControllerSpringBootIntegrationTest.java
+++ b/chutney/server/src/test/java/blackbox/SecuredControllerSpringBootIntegrationTest.java
@@ -10,6 +10,7 @@ package blackbox;
 import static fr.enedis.chutney.server.core.domain.security.Authorization.ADMIN_ACCESS;
 import static fr.enedis.chutney.server.core.domain.security.Authorization.CAMPAIGN_READ;
 import static fr.enedis.chutney.server.core.domain.security.Authorization.CAMPAIGN_WRITE;
+import static fr.enedis.chutney.server.core.domain.security.Authorization.DATASET_WRITE;
 import static fr.enedis.chutney.server.core.domain.security.Authorization.ENVIRONMENT_READ;
 import static fr.enedis.chutney.server.core.domain.security.Authorization.ENVIRONMENT_WRITE;
 import static fr.enedis.chutney.server.core.domain.security.Authorization.EXECUTION_READ;
@@ -299,6 +300,9 @@ public class SecuredControllerSpringBootIntegrationTest {
             {POST, NodeNetworkController.WRAP_UP_URL, ADMIN_ACCESS.name(), "{\"agentsGraph\":{\"agents\":[]},\"networkConfiguration\":{\"creationDate\":\"2021-09-06T10:08:36.569227Z\",\"agentNetworkConfiguration\":[],\"environmentsConfiguration\":[]}}", OK},
 
             {POST, AccessTokenController.BASE_URL, ADMIN_ACCESS.name(), "{\"user\":\"username\"}", OK},
+            {POST, AccessTokenController.BASE_URL, CAMPAIGN_WRITE.name(), "{\"user\":\"username\"}", OK},
+            {POST, AccessTokenController.BASE_URL, DATASET_WRITE.name(), "{\"user\":\"username\"}", OK},
+            {POST, AccessTokenController.BASE_URL, SCENARIO_WRITE.name(), "{\"user\":\"username\"}", OK},
         };
     }
 

--- a/chutney/server/src/test/java/blackbox/SecuredControllerSpringBootIntegrationTest.java
+++ b/chutney/server/src/test/java/blackbox/SecuredControllerSpringBootIntegrationTest.java
@@ -300,13 +300,13 @@ public class SecuredControllerSpringBootIntegrationTest {
             // Must be at the end because the network configuration is in wrong state, why ??
             {POST, NodeNetworkController.WRAP_UP_URL, ADMIN_ACCESS.name(), "{\"agentsGraph\":{\"agents\":[]},\"networkConfiguration\":{\"creationDate\":\"2021-09-06T10:08:36.569227Z\",\"agentNetworkConfiguration\":[],\"environmentsConfiguration\":[]}}", OK},
 
-            {POST, AccessTokenController.BASE_URL, ADMIN_ACCESS.name(), "{\"user\":\"username\"}", OK},
-            {POST, AccessTokenController.BASE_URL, CAMPAIGN_WRITE.name(), "{\"user\":\"username\"}", OK},
-            {POST, AccessTokenController.BASE_URL, DATASET_WRITE.name(), "{\"user\":\"username\"}", OK},
-            {POST, AccessTokenController.BASE_URL, DATASET_READ.name(), "{\"user\":\"username\"}", OK},
-            {POST, AccessTokenController.BASE_URL, SCENARIO_WRITE.name(), "{\"user\":\"username\"}", OK},
-            {POST, AccessTokenController.BASE_URL, SCENARIO_READ.name(), "{\"user\":\"username\"}", OK},
-            {POST, AccessTokenController.BASE_URL, ENVIRONMENT_READ.name(), "{\"user\":\"username\"}", OK},
+            {POST, AccessTokenController.BASE_URL, ADMIN_ACCESS.name(), "{\"note\":\"note\",\"expiresAt\":\"2026-06-30\"}", OK},
+            {POST, AccessTokenController.BASE_URL, CAMPAIGN_WRITE.name(), "{\"note\":\"note\",\"expiresAt\":\"2026-06-30\"}", OK},
+            {POST, AccessTokenController.BASE_URL, DATASET_WRITE.name(), "{\"note\":\"note\",\"expiresAt\":\"2026-06-30\"}", OK},
+            {POST, AccessTokenController.BASE_URL, DATASET_READ.name(), "{\"note\":\"note\",\"expiresAt\":\"2026-06-30\"}", OK},
+            {POST, AccessTokenController.BASE_URL, SCENARIO_WRITE.name(), "{\"note\":\"note\",\"expiresAt\":\"2026-06-30\"}", OK},
+            {POST, AccessTokenController.BASE_URL, SCENARIO_READ.name(), "{\"note\":\"note\",\"expiresAt\":\"2026-06-30\"}", OK},
+            {POST, AccessTokenController.BASE_URL, ENVIRONMENT_READ.name(), "{\"note\":\"note\",\"expiresAt\":\"2026-06-30\"}", OK},
         };
     }
 

--- a/chutney/server/src/test/java/blackbox/SecuredControllerSpringBootIntegrationTest.java
+++ b/chutney/server/src/test/java/blackbox/SecuredControllerSpringBootIntegrationTest.java
@@ -10,6 +10,7 @@ package blackbox;
 import static fr.enedis.chutney.server.core.domain.security.Authorization.ADMIN_ACCESS;
 import static fr.enedis.chutney.server.core.domain.security.Authorization.CAMPAIGN_READ;
 import static fr.enedis.chutney.server.core.domain.security.Authorization.CAMPAIGN_WRITE;
+import static fr.enedis.chutney.server.core.domain.security.Authorization.DATASET_READ;
 import static fr.enedis.chutney.server.core.domain.security.Authorization.DATASET_WRITE;
 import static fr.enedis.chutney.server.core.domain.security.Authorization.ENVIRONMENT_READ;
 import static fr.enedis.chutney.server.core.domain.security.Authorization.ENVIRONMENT_WRITE;
@@ -302,7 +303,10 @@ public class SecuredControllerSpringBootIntegrationTest {
             {POST, AccessTokenController.BASE_URL, ADMIN_ACCESS.name(), "{\"user\":\"username\"}", OK},
             {POST, AccessTokenController.BASE_URL, CAMPAIGN_WRITE.name(), "{\"user\":\"username\"}", OK},
             {POST, AccessTokenController.BASE_URL, DATASET_WRITE.name(), "{\"user\":\"username\"}", OK},
+            {POST, AccessTokenController.BASE_URL, DATASET_READ.name(), "{\"user\":\"username\"}", OK},
             {POST, AccessTokenController.BASE_URL, SCENARIO_WRITE.name(), "{\"user\":\"username\"}", OK},
+            {POST, AccessTokenController.BASE_URL, SCENARIO_READ.name(), "{\"user\":\"username\"}", OK},
+            {POST, AccessTokenController.BASE_URL, ENVIRONMENT_READ.name(), "{\"user\":\"username\"}", OK},
         };
     }
 

--- a/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
@@ -85,7 +85,7 @@ class AuthenticationServiceTest {
         when(accessTokensService.userFromToken(token)).thenReturn(Optional.of(new AccessToken("id", "user", "hashed",
             Instant.now().minus(1, ChronoUnit.DAYS))));
 
-        Authentication authentication = sut.getAuthentication("X-API-KEY", "/path");
+        Authentication authentication = sut.getAuthentication("token", "/path");
 
         assertThat(authentication).isInstanceOf(ApiKeyAuthentication.class);
         assertThat(((ApiKeyAuthentication)authentication).getAuthorities())

--- a/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
@@ -9,7 +9,6 @@ package fr.enedis.chutney.security.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -21,7 +20,6 @@ import fr.enedis.chutney.server.core.domain.security.User;
 import fr.enedis.chutney.server.core.domain.security.UserRoles;
 import fr.enedis.chutney.tokens.domain.AccessToken;
 import fr.enedis.chutney.tokens.domain.AccessTokensService;
-import jakarta.servlet.http.HttpServletRequest;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -83,13 +81,11 @@ class AuthenticationServiceTest {
 
     @Test
     void get_api_key_authentication() {
-        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
         String token = "token";
-        when(httpServletRequest.getHeader(eq("X-API-KEY"))).thenReturn(token);
         when(accessTokensService.userFromToken(token)).thenReturn(Optional.of(new AccessToken("id", "user", "hashed",
             Instant.now().minus(1, ChronoUnit.DAYS))));
 
-        Authentication authentication = sut.getAuthentication(httpServletRequest);
+        Authentication authentication = sut.getAuthentication("X-API-KEY", "/path");
 
         assertThat(authentication).isInstanceOf(ApiKeyAuthentication.class);
         assertThat(((ApiKeyAuthentication)authentication).getAuthorities())
@@ -98,11 +94,9 @@ class AuthenticationServiceTest {
 
     @Test
     void throw_exception_when_api_key_is_wrong() {
-        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
         String token = "token";
-        when(httpServletRequest.getHeader(eq("X-API-KEY"))).thenReturn(token);
         when(accessTokensService.userFromToken(token)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> sut.getAuthentication(httpServletRequest)).isInstanceOf(BadCredentialsException.class);
+        assertThatThrownBy(() -> sut.getAuthentication("X-API-KEY", "/path")).isInstanceOf(BadCredentialsException.class);
     }
 }

--- a/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
@@ -19,8 +19,11 @@ import fr.enedis.chutney.server.core.domain.security.Role;
 import fr.enedis.chutney.server.core.domain.security.RoleNotFoundException;
 import fr.enedis.chutney.server.core.domain.security.User;
 import fr.enedis.chutney.server.core.domain.security.UserRoles;
+import fr.enedis.chutney.tokens.domain.AccessToken;
 import fr.enedis.chutney.tokens.domain.AccessTokensService;
 import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,7 +86,8 @@ class AuthenticationServiceTest {
         HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
         String token = "token";
         when(httpServletRequest.getHeader(eq("X-API-KEY"))).thenReturn(token);
-        when(accessTokensService.userFromToken(token)).thenReturn(Optional.of("user"));
+        when(accessTokensService.userFromToken(token)).thenReturn(Optional.of(new AccessToken("id", "user", "hashed",
+            Instant.now().minus(1, ChronoUnit.DAYS))));
 
         Authentication authentication = sut.getAuthentication(httpServletRequest);
 

--- a/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
@@ -83,7 +83,7 @@ class AuthenticationServiceTest {
     void get_api_key_authentication() {
         String token = "token";
         String user = "user";
-        when(accessTokensService.userFromToken(token)).thenReturn(Optional.of(
+        when(accessTokensService.accessTokenFromRaw(token)).thenReturn(Optional.of(
             new AccessToken(user, "note", "hash",
             Instant.now().plus(1, ChronoUnit.DAYS))));
         String role = "role";
@@ -108,7 +108,7 @@ class AuthenticationServiceTest {
     @Test
     void throw_exception_when_api_key_is_wrong() {
         String token = "token";
-        when(accessTokensService.userFromToken(token)).thenReturn(Optional.empty());
+        when(accessTokensService.accessTokenFromRaw(token)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> sut.getAuthentication("X-API-KEY", "/path")).isInstanceOf(BadCredentialsException.class);
     }

--- a/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
@@ -9,30 +9,38 @@ package fr.enedis.chutney.security.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import fr.enedis.chutney.security.ApiKeyAuthentication;
 import fr.enedis.chutney.server.core.domain.security.Authorization;
 import fr.enedis.chutney.server.core.domain.security.Role;
 import fr.enedis.chutney.server.core.domain.security.RoleNotFoundException;
 import fr.enedis.chutney.server.core.domain.security.User;
 import fr.enedis.chutney.server.core.domain.security.UserRoles;
+import fr.enedis.chutney.tokens.domain.AccessTokensService;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 class AuthenticationServiceTest {
 
     private final Authorizations authorizations = mock(Authorizations.class);
+    private final AccessTokensService accessTokensService = mock(AccessTokensService.class);
     private AuthenticationService sut;
 
     @BeforeEach
     public void setUp() {
-        sut = new AuthenticationService(authorizations);
+        sut = new AuthenticationService(authorizations, accessTokensService);
     }
 
     @Test
-    public void get_role_from_user_id_with_write_implies_read() {
+    void get_role_from_user_id_with_write_implies_read() {
         // Given
         Role expectedRole = Role.builder()
             .withName("expectedRole")
@@ -58,7 +66,7 @@ class AuthenticationServiceTest {
     }
 
     @Test
-    public void throw_user_not_found_when_get_role_for_authentication_for_an_unknown_user() {
+    void throw_user_not_found_when_get_role_for_authentication_for_an_unknown_user() {
         // Given
         when(authorizations.read()).thenReturn(
             UserRoles.builder().build()
@@ -67,5 +75,29 @@ class AuthenticationServiceTest {
         // When
         assertThatThrownBy(() -> sut.userRoleById("unknown-user"))
             .isInstanceOf(RoleNotFoundException.class);
+    }
+
+    @Test
+    void get_api_key_authentication() {
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+        String token = "token";
+        when(httpServletRequest.getHeader(eq("X-API-KEY"))).thenReturn(token);
+        when(accessTokensService.matchToken(token)).thenReturn(true);
+
+        Authentication authentication = sut.getAuthentication(httpServletRequest);
+
+        assertThat(authentication).isInstanceOf(ApiKeyAuthentication.class);
+        assertThat(((ApiKeyAuthentication)authentication).getAuthorities())
+            .containsExactly(new SimpleGrantedAuthority(Authorization.SCENARIO_WRITE.name()));
+    }
+
+    @Test
+    void throw_exception_when_api_key_is_wrong() {
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+        String token = "token";
+        when(httpServletRequest.getHeader(eq("X-API-KEY"))).thenReturn(token);
+        when(accessTokensService.matchToken(token)).thenReturn(false);
+
+        assertThatThrownBy(() -> sut.getAuthentication(httpServletRequest)).isInstanceOf(BadCredentialsException.class);
     }
 }

--- a/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
@@ -82,8 +82,9 @@ class AuthenticationServiceTest {
     @Test
     void get_api_key_authentication() {
         String token = "token";
-        when(accessTokensService.userFromToken(token)).thenReturn(Optional.of(new AccessToken("id", "user", "hashed",
-            Instant.now().minus(1, ChronoUnit.DAYS))));
+        when(accessTokensService.userFromToken(token)).thenReturn(Optional.of(
+            new AccessToken("user", "note", "hash",
+            Instant.now().plus(1, ChronoUnit.DAYS))));
 
         Authentication authentication = sut.getAuthentication("token", "/path");
 

--- a/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
@@ -22,6 +22,7 @@ import fr.enedis.chutney.server.core.domain.security.UserRoles;
 import fr.enedis.chutney.tokens.domain.AccessTokensService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -82,7 +83,7 @@ class AuthenticationServiceTest {
         HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
         String token = "token";
         when(httpServletRequest.getHeader(eq("X-API-KEY"))).thenReturn(token);
-        when(accessTokensService.matchToken(token)).thenReturn(true);
+        when(accessTokensService.userFromToken(token)).thenReturn(Optional.of("user"));
 
         Authentication authentication = sut.getAuthentication(httpServletRequest);
 
@@ -96,7 +97,7 @@ class AuthenticationServiceTest {
         HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
         String token = "token";
         when(httpServletRequest.getHeader(eq("X-API-KEY"))).thenReturn(token);
-        when(accessTokensService.matchToken(token)).thenReturn(false);
+        when(accessTokensService.userFromToken(token)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> sut.getAuthentication(httpServletRequest)).isInstanceOf(BadCredentialsException.class);
     }

--- a/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
@@ -82,15 +82,27 @@ class AuthenticationServiceTest {
     @Test
     void get_api_key_authentication() {
         String token = "token";
+        String user = "user";
         when(accessTokensService.userFromToken(token)).thenReturn(Optional.of(
-            new AccessToken("user", "note", "hash",
+            new AccessToken(user, "note", "hash",
             Instant.now().plus(1, ChronoUnit.DAYS))));
+        String role = "role";
+        when(authorizations.read()).thenReturn(
+            UserRoles.builder()
+                .withRoles(List.of(Role.builder()
+                    .withName(role)
+                    .withAuthorizations(List.of(Authorization.SCENARIO_WRITE.name()))
+                    .build()))
+                .withUsers(List.of(User.builder().withId(user).withRole(role).build()))
+                .build()
+        );
 
         Authentication authentication = sut.getAuthentication("token", "/path");
 
         assertThat(authentication).isInstanceOf(ApiKeyAuthentication.class);
         assertThat(((ApiKeyAuthentication)authentication).getAuthorities())
-            .containsExactly(new SimpleGrantedAuthority(Authorization.SCENARIO_WRITE.name()));
+            .containsExactly(new SimpleGrantedAuthority(Authorization.SCENARIO_WRITE.name()),
+                new SimpleGrantedAuthority(Authorization.SCENARIO_READ.name()));
     }
 
     @Test

--- a/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/security/domain/AuthenticationServiceTest.java
@@ -26,8 +26,6 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 class AuthenticationServiceTest {
@@ -97,10 +95,10 @@ class AuthenticationServiceTest {
                 .build()
         );
 
-        Authentication authentication = sut.getAuthentication("token", "/path");
+        ApiKeyAuthentication authentication = sut.getAuthentication("token");
 
         assertThat(authentication).isInstanceOf(ApiKeyAuthentication.class);
-        assertThat(((ApiKeyAuthentication)authentication).getAuthorities())
+        assertThat(authentication.getAuthorities())
             .containsExactly(new SimpleGrantedAuthority(Authorization.SCENARIO_WRITE.name()),
                 new SimpleGrantedAuthority(Authorization.SCENARIO_READ.name()));
     }
@@ -110,6 +108,6 @@ class AuthenticationServiceTest {
         String token = "token";
         when(accessTokensService.accessTokenFromRaw(token)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> sut.getAuthentication("X-API-KEY", "/path")).isInstanceOf(BadCredentialsException.class);
+        assertThatThrownBy(() -> sut.getAuthentication("X-API-KEY")).isInstanceOf(InvalidApiKeyException.class);
     }
 }

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -20,7 +20,7 @@ class AccessTokensServiceTest {
 
     @Test
     void create_token() {
-        String token = sut.crateToken("ulysse");
+        String token = sut.createToken("ulysse");
         assertThat(token).isNotEmpty();
         verify(accessTokensRepository).createToken();
     }

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -43,7 +43,7 @@ class AccessTokensServiceTest {
         var user = "bach";
         var token = sut.createToken(user);
         var encoded = new BCryptPasswordEncoder().encode(token);
-        when(accessTokensRepository.getTokens()).thenReturn(List.of(encoded));
+        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, encoded)));
         assertThat(sut.matchToken(token, user)).isTrue();
     }
 
@@ -51,15 +51,16 @@ class AccessTokensServiceTest {
     void does_not_match_wrong_token() {
         String user = "bach";
         var token = sut.createToken(user);
-        when(accessTokensRepository.getTokens()).thenReturn(List.of("wrong"));
+        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, "wrong")));
         assertThat(sut.matchToken(token, user)).isFalse();
     }
 
     @Test
     void does_not_match_token_for_wrong_user() {
-        var token = sut.createToken("bach");
+        var user = "bach";
+        var token = sut.createToken(user);
         var encoded = new BCryptPasswordEncoder().encode(token);
-        when(accessTokensRepository.getTokens()).thenReturn(List.of(encoded));
+        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, encoded)));
         assertThat(sut.matchToken(token, "wrong")).isFalse();
     }
 }

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -45,7 +45,7 @@ class AccessTokensServiceTest {
         var user = "bach";
         var token = sut.createToken(user);
         var encoded = new BCryptPasswordEncoder().encode(token);
-        AccessToken accessToken = new AccessToken("id", user, encoded, Instant.now());
+        AccessToken accessToken = new AccessToken(user, "note", encoded, Instant.now().plus(1, ChronoUnit.DAYS));
         when(accessTokensRepository.getTokens()).thenReturn(List.of(accessToken));
         assertThat(sut.userFromToken(token)).contains(accessToken);
     }
@@ -54,7 +54,7 @@ class AccessTokensServiceTest {
     void does_not_match_wrong_token() {
         String user = "bach";
         var token = sut.createToken(user);
-        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, "wrong", Instant.now())));
+        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken(user, "note", "wrong", Instant.now().plus(1, ChronoUnit.DAYS))));
         assertThat(sut.userFromToken(token)).isEmpty();
     }
 
@@ -63,7 +63,7 @@ class AccessTokensServiceTest {
         var user = "bach";
         var token = sut.createToken(user);
         var encoded = new BCryptPasswordEncoder().encode(token);
-        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, encoded, Instant.now().minus(91, ChronoUnit.DAYS))));
+        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken(user, "note", encoded, Instant.now().minus(1, ChronoUnit.DAYS))));
         assertThat(sut.userFromToken(token)).isEmpty();
     }
 }

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
@@ -21,25 +23,43 @@ class AccessTokensServiceTest {
     private final AccessTokensRepository accessTokensRepository = Mockito.mock(AccessTokensRepository.class);
     private final AccessTokensService sut = new AccessTokensService(accessTokensRepository);
 
+    @Captor
+    private final ArgumentCaptor<AccessToken> argumentCaptor = ArgumentCaptor.forClass(AccessToken.class);
+
     @Test
     void create_token() {
-        var token = sut.createToken("ulysse");
+        var user = "ulysse";
+        var token = sut.createToken(user);
+
         assertThat(token).isNotEmpty();
-        verify(accessTokensRepository).createToken();
+
+        verify(accessTokensRepository).createToken(argumentCaptor.capture());
+        AccessToken value = argumentCaptor.getValue();
+        assertThat(value.user()).isEqualTo(user);
     }
 
     @Test
     void match_right_token() {
-        var token = sut.createToken("tokyo");
+        var user = "bach";
+        var token = sut.createToken(user);
         var encoded = new BCryptPasswordEncoder().encode(token);
         when(accessTokensRepository.getTokens()).thenReturn(List.of(encoded));
-        assertThat(sut.matchToken(token)).isTrue();
+        assertThat(sut.matchToken(token, user)).isTrue();
     }
 
     @Test
-    void does_not_match_right_token() {
-        var token = sut.createToken("tokyo");
+    void does_not_match_wrong_token() {
+        String user = "bach";
+        var token = sut.createToken(user);
         when(accessTokensRepository.getTokens()).thenReturn(List.of("wrong"));
-        assertThat(sut.matchToken(token)).isFalse();
+        assertThat(sut.matchToken(token, user)).isFalse();
+    }
+
+    @Test
+    void does_not_match_token_for_wrong_user() {
+        var token = sut.createToken("bach");
+        var encoded = new BCryptPasswordEncoder().encode(token);
+        when(accessTokensRepository.getTokens()).thenReturn(List.of(encoded));
+        assertThat(sut.matchToken(token, "wrong")).isFalse();
     }
 }

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -45,8 +45,9 @@ class AccessTokensServiceTest {
         var user = "bach";
         var token = sut.createToken(user);
         var encoded = new BCryptPasswordEncoder().encode(token);
-        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, encoded, Instant.now())));
-        assertThat(sut.userFromToken(token)).contains(user);
+        AccessToken accessToken = new AccessToken("id", user, encoded, Instant.now());
+        when(accessTokensRepository.getTokens()).thenReturn(List.of(accessToken));
+        assertThat(sut.userFromToken(token)).contains(accessToken);
     }
 
     @Test

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -46,7 +46,7 @@ class AccessTokensServiceTest {
         var token = sut.createToken(user);
         var encoded = new BCryptPasswordEncoder().encode(token);
         when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, encoded, Instant.now())));
-        assertThat(sut.matchToken(token, user)).isTrue();
+        assertThat(sut.matchToken(token)).isTrue();
     }
 
     @Test
@@ -54,16 +54,7 @@ class AccessTokensServiceTest {
         String user = "bach";
         var token = sut.createToken(user);
         when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, "wrong", Instant.now())));
-        assertThat(sut.matchToken(token, user)).isFalse();
-    }
-
-    @Test
-    void does_not_match_token_for_wrong_user() {
-        var user = "bach";
-        var token = sut.createToken(user);
-        var encoded = new BCryptPasswordEncoder().encode(token);
-        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, encoded, Instant.now())));
-        assertThat(sut.matchToken(token, "wrong")).isFalse();
+        assertThat(sut.matchToken(token)).isFalse();
     }
 
     @Test
@@ -72,6 +63,6 @@ class AccessTokensServiceTest {
         var token = sut.createToken(user);
         var encoded = new BCryptPasswordEncoder().encode(token);
         when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, encoded, Instant.now().minus(91, ChronoUnit.DAYS))));
-        assertThat(sut.matchToken(token, user)).isFalse();
+        assertThat(sut.matchToken(token)).isFalse();
     }
 }

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -9,9 +9,12 @@ package fr.enedis.chutney.tokens.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 class AccessTokensServiceTest {
 
@@ -20,8 +23,23 @@ class AccessTokensServiceTest {
 
     @Test
     void create_token() {
-        String token = sut.createToken("ulysse");
+        var token = sut.createToken("ulysse");
         assertThat(token).isNotEmpty();
         verify(accessTokensRepository).createToken();
+    }
+
+    @Test
+    void match_right_token() {
+        var token = sut.createToken("tokyo");
+        var encoded = new BCryptPasswordEncoder().encode(token);
+        when(accessTokensRepository.getTokens()).thenReturn(List.of(encoded));
+        assertThat(sut.matchToken(token)).isTrue();
+    }
+
+    @Test
+    void does_not_match_right_token() {
+        var token = sut.createToken("tokyo");
+        when(accessTokensRepository.getTokens()).thenReturn(List.of("wrong"));
+        assertThat(sut.matchToken(token)).isFalse();
     }
 }

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -46,7 +46,7 @@ class AccessTokensServiceTest {
         var token = sut.createToken(user);
         var encoded = new BCryptPasswordEncoder().encode(token);
         when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, encoded, Instant.now())));
-        assertThat(sut.matchToken(token)).isTrue();
+        assertThat(sut.userFromToken(token)).contains(user);
     }
 
     @Test
@@ -54,7 +54,7 @@ class AccessTokensServiceTest {
         String user = "bach";
         var token = sut.createToken(user);
         when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, "wrong", Instant.now())));
-        assertThat(sut.matchToken(token)).isFalse();
+        assertThat(sut.userFromToken(token)).isEmpty();
     }
 
     @Test
@@ -63,6 +63,6 @@ class AccessTokensServiceTest {
         var token = sut.createToken(user);
         var encoded = new BCryptPasswordEncoder().encode(token);
         when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, encoded, Instant.now().minus(91, ChronoUnit.DAYS))));
-        assertThat(sut.matchToken(token)).isFalse();
+        assertThat(sut.userFromToken(token)).isEmpty();
     }
 }

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.tokens.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class AccessTokensServiceTest {
+
+    private final AccessTokensRepository accessTokensRepository = Mockito.mock(AccessTokensRepository.class);
+    private final AccessTokensService sut = new AccessTokensService(accessTokensRepository);
+
+    @Test
+    void create_token() {
+        String token = sut.crateToken("ulysse");
+        assertThat(token).isNotEmpty();
+        verify(accessTokensRepository).createToken();
+    }
+}

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import fr.enedis.chutney.tokens.infra.BCryptAccessTokenEncoder;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -23,7 +24,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 class AccessTokensServiceTest {
 
     private final AccessTokensRepository accessTokensRepository = Mockito.mock(AccessTokensRepository.class);
-    private final AccessTokensService sut = new AccessTokensService(accessTokensRepository);
+    private final AccessTokensService sut = new AccessTokensService(accessTokensRepository, new BCryptAccessTokenEncoder());
 
     @Captor
     private final ArgumentCaptor<AccessToken> argumentCaptor = ArgumentCaptor.forClass(AccessToken.class);

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -48,7 +48,7 @@ class AccessTokensServiceTest {
         var encoded = new BCryptPasswordEncoder().encode(token);
         AccessToken accessToken = new AccessToken(user, "note", encoded, Instant.now().plus(1, ChronoUnit.DAYS));
         when(accessTokensRepository.getTokens()).thenReturn(List.of(accessToken));
-        assertThat(sut.userFromToken(token)).contains(accessToken);
+        assertThat(sut.accessTokenFromRaw(token)).contains(accessToken);
     }
 
     @Test
@@ -56,7 +56,7 @@ class AccessTokensServiceTest {
         String user = "bach";
         var token = sut.createToken(user, "note", Instant.now().plus(2, ChronoUnit.DAYS));
         when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken(user, "note", "wrong", Instant.now().plus(1, ChronoUnit.DAYS))));
-        assertThat(sut.userFromToken(token)).isEmpty();
+        assertThat(sut.accessTokenFromRaw(token)).isEmpty();
     }
 
     @Test
@@ -65,6 +65,6 @@ class AccessTokensServiceTest {
         var token = sut.createToken(user, "note", Instant.now());
         var encoded = new BCryptPasswordEncoder().encode(token);
         when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken(user, "note", encoded, Instant.now().minus(1, ChronoUnit.DAYS))));
-        assertThat(sut.userFromToken(token)).isEmpty();
+        assertThat(sut.accessTokenFromRaw(token)).isEmpty();
     }
 }

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -31,7 +31,7 @@ class AccessTokensServiceTest {
     @Test
     void create_token() {
         var user = "ulysse";
-        var token = sut.createToken(user);
+        var token = sut.createToken(user, "note", Instant.now().plus(1, ChronoUnit.DAYS));
 
         assertThat(token).isNotEmpty();
 
@@ -43,7 +43,7 @@ class AccessTokensServiceTest {
     @Test
     void match_right_token() {
         var user = "bach";
-        var token = sut.createToken(user);
+        var token = sut.createToken(user, "note", Instant.now().plus(2, ChronoUnit.DAYS));
         var encoded = new BCryptPasswordEncoder().encode(token);
         AccessToken accessToken = new AccessToken(user, "note", encoded, Instant.now().plus(1, ChronoUnit.DAYS));
         when(accessTokensRepository.getTokens()).thenReturn(List.of(accessToken));
@@ -53,7 +53,7 @@ class AccessTokensServiceTest {
     @Test
     void does_not_match_wrong_token() {
         String user = "bach";
-        var token = sut.createToken(user);
+        var token = sut.createToken(user, "note", Instant.now().plus(2, ChronoUnit.DAYS));
         when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken(user, "note", "wrong", Instant.now().plus(1, ChronoUnit.DAYS))));
         assertThat(sut.userFromToken(token)).isEmpty();
     }
@@ -61,7 +61,7 @@ class AccessTokensServiceTest {
     @Test
     void does_not_match_revoked_token() {
         var user = "bach";
-        var token = sut.createToken(user);
+        var token = sut.createToken(user, "note", Instant.now());
         var encoded = new BCryptPasswordEncoder().encode(token);
         when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken(user, "note", encoded, Instant.now().minus(1, ChronoUnit.DAYS))));
         assertThat(sut.userFromToken(token)).isEmpty();

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -43,7 +45,7 @@ class AccessTokensServiceTest {
         var user = "bach";
         var token = sut.createToken(user);
         var encoded = new BCryptPasswordEncoder().encode(token);
-        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, encoded)));
+        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, encoded, Instant.now())));
         assertThat(sut.matchToken(token, user)).isTrue();
     }
 
@@ -51,7 +53,7 @@ class AccessTokensServiceTest {
     void does_not_match_wrong_token() {
         String user = "bach";
         var token = sut.createToken(user);
-        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, "wrong")));
+        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, "wrong", Instant.now())));
         assertThat(sut.matchToken(token, user)).isFalse();
     }
 
@@ -60,7 +62,16 @@ class AccessTokensServiceTest {
         var user = "bach";
         var token = sut.createToken(user);
         var encoded = new BCryptPasswordEncoder().encode(token);
-        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, encoded)));
+        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, encoded, Instant.now())));
         assertThat(sut.matchToken(token, "wrong")).isFalse();
+    }
+
+    @Test
+    void does_not_match_revoked_token() {
+        var user = "bach";
+        var token = sut.createToken(user);
+        var encoded = new BCryptPasswordEncoder().encode(token);
+        when(accessTokensRepository.getTokens()).thenReturn(List.of(new AccessToken("id", user, encoded, Instant.now().minus(91, ChronoUnit.DAYS))));
+        assertThat(sut.matchToken(token, user)).isFalse();
     }
 }

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -52,6 +52,16 @@ class AccessTokensServiceTest {
     }
 
     @Test
+    void match_right_token_without_expired_date() {
+        var user = "bach";
+        var token = sut.createToken(user, "note", null);
+        var encoded = new BCryptPasswordEncoder().encode(token);
+        AccessToken accessToken = new AccessToken(user, "note", encoded, null);
+        when(accessTokensRepository.getTokens()).thenReturn(List.of(accessToken));
+        assertThat(sut.accessTokenFromRaw(token)).contains(accessToken);
+    }
+
+    @Test
     void does_not_match_wrong_token() {
         String user = "bach";
         var token = sut.createToken(user, "note", Instant.now().plus(2, ChronoUnit.DAYS));

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/domain/AccessTokensServiceTest.java
@@ -60,7 +60,7 @@ class AccessTokensServiceTest {
     }
 
     @Test
-    void does_not_match_revoked_token() {
+    void does_not_match_expired_token() {
         var user = "bach";
         var token = sut.createToken(user, "note", Instant.now());
         var encoded = new BCryptPasswordEncoder().encode(token);

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepositoryTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepositoryTest.java
@@ -18,8 +18,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import util.infra.AbstractLocalDatabaseTest;
 import util.infra.EnableH2MemTestInfra;
+import util.infra.EnablePostgreSQLTestInfra;
+import util.infra.EnableSQLiteTestInfra;
 
 @EnableH2MemTestInfra
+@EnablePostgreSQLTestInfra
+@EnableSQLiteTestInfra
 class DatabaseAccessTokensDBRepositoryTest extends AbstractLocalDatabaseTest {
 
     @Autowired

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepositoryTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepositoryTest.java
@@ -27,7 +27,7 @@ class DatabaseAccessTokensDBRepositoryTest extends AbstractLocalDatabaseTest {
 
     @Test
     void get_tokens() {
-        sut.createToken(new AccessToken("pedro", "note", "87654",
+        sut.createToken(new AccessToken("pedro", "note", "hash",
             Instant.now().plus(1, ChronoUnit.HOURS)));
         Collection<AccessToken> tokens = sut.getTokens();
         assertThat(tokens).hasSize(1);

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepositoryTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepositoryTest.java
@@ -27,8 +27,8 @@ class DatabaseAccessTokensDBRepositoryTest extends AbstractLocalDatabaseTest {
 
     @Test
     void get_tokens() {
-        sut.createToken(new AccessToken("id", "pedro", "87654",
-            Instant.now().minus(1, ChronoUnit.HOURS)));
+        sut.createToken(new AccessToken("pedro", "note", "87654",
+            Instant.now().plus(1, ChronoUnit.HOURS)));
         Collection<AccessToken> tokens = sut.getTokens();
         assertThat(tokens).hasSize(1);
     }

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepositoryTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepositoryTest.java
@@ -14,6 +14,7 @@ import fr.enedis.chutney.tokens.domain.AccessTokensRepository;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import util.infra.AbstractLocalDatabaseTest;
@@ -21,19 +22,34 @@ import util.infra.EnableH2MemTestInfra;
 import util.infra.EnablePostgreSQLTestInfra;
 import util.infra.EnableSQLiteTestInfra;
 
-@EnableH2MemTestInfra
-@EnablePostgreSQLTestInfra
-@EnableSQLiteTestInfra
-class DatabaseAccessTokensDBRepositoryTest extends AbstractLocalDatabaseTest {
+class DatabaseAccessTokensDBRepositoryTest {
 
-    @Autowired
-    private AccessTokensRepository sut;
+    @Nested
+    @EnableH2MemTestInfra
+    class H2 extends DatabaseAccessTokensDBRepositoryTest.AllTests {
+    }
 
-    @Test
-    void get_tokens() {
-        sut.createToken(new AccessToken("pedro", "note", "hash",
-            Instant.now().plus(1, ChronoUnit.HOURS)));
-        Collection<AccessToken> tokens = sut.getTokens();
-        assertThat(tokens).hasSize(1);
+    @Nested
+    @EnableSQLiteTestInfra
+    class SQLite extends DatabaseAccessTokensDBRepositoryTest.AllTests {
+    }
+
+    @Nested
+    @EnablePostgreSQLTestInfra
+    class PostgreSQL extends DatabaseAccessTokensDBRepositoryTest.AllTests {
+    }
+
+    static abstract class AllTests extends AbstractLocalDatabaseTest {
+
+        @Autowired
+        private AccessTokensRepository sut;
+
+        @Test
+        void get_tokens() {
+            sut.createToken(new AccessToken("pedro", "note", "hash",
+                Instant.now().plus(1, ChronoUnit.HOURS)));
+            Collection<AccessToken> tokens = sut.getTokens();
+            assertThat(tokens).hasSize(1);
+        }
     }
 }

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepositoryTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepositoryTest.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.tokens.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fr.enedis.chutney.tokens.domain.AccessToken;
+import fr.enedis.chutney.tokens.domain.AccessTokensRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import util.infra.AbstractLocalDatabaseTest;
+import util.infra.EnableH2MemTestInfra;
+
+@EnableH2MemTestInfra
+class DatabaseAccessTokensDBRepositoryTest extends AbstractLocalDatabaseTest {
+
+    @Autowired
+    private AccessTokensRepository sut;
+
+    @Test
+    void get_tokens() {
+        sut.createToken(new AccessToken("id", "pedro", "87654",
+            Instant.now().minus(1, ChronoUnit.HOURS)));
+        Collection<AccessToken> tokens = sut.getTokens();
+        assertThat(tokens).hasSize(1);
+    }
+}

--- a/chutney/server/src/test/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepositoryTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/tokens/infra/DatabaseAccessTokensDBRepositoryTest.java
@@ -13,7 +13,7 @@ import fr.enedis.chutney.tokens.domain.AccessToken;
 import fr.enedis.chutney.tokens.domain.AccessTokensRepository;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Collection;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,7 +48,7 @@ class DatabaseAccessTokensDBRepositoryTest {
         void get_tokens() {
             sut.createToken(new AccessToken("pedro", "note", "hash",
                 Instant.now().plus(1, ChronoUnit.HOURS)));
-            Collection<AccessToken> tokens = sut.getTokens();
+            List<AccessToken> tokens = sut.getTokens();
             assertThat(tokens).hasSize(1);
         }
     }

--- a/chutney/server/src/test/java/util/infra/EnableJpa.java
+++ b/chutney/server/src/test/java/util/infra/EnableJpa.java
@@ -15,6 +15,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @EnableJpaRepositories(
     basePackages = {
+        "fr.enedis.chutney.tokens.infra",
         "fr.enedis.chutney.scenario.infra",
         "fr.enedis.chutney.campaign.infra",
         "fr.enedis.chutney.execution.infra.storage"
@@ -23,6 +24,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 )
 @ComponentScan(
     basePackages = {
+        "fr.enedis.chutney.tokens.infra",
         "fr.enedis.chutney.campaign.infra",
         "fr.enedis.chutney.scenario.infra",
         "fr.enedis.chutney.execution.infra.storage"

--- a/kotlin-dsl/src/main/kotlin/fr/enedis/chutney/kotlin/synchronize/ChutneyServerServiceImpl.kt
+++ b/kotlin-dsl/src/main/kotlin/fr/enedis/chutney/kotlin/synchronize/ChutneyServerServiceImpl.kt
@@ -135,7 +135,7 @@ object ChutneyServerServiceImpl : ChutneyServerService {
     }
 
     override fun getEnvironments(serverInfo: ChutneyServerInfo): Set<EnvironmentDto> {
-        return HttpClient.get(serverInfo, "/api/v2/environment")
+        return HttpClient.get(serverInfo, "/api/v2/environments")
     }
 
     private const val chutneyDatasetEndpoint = "/api/v1/datasets"

--- a/kotlin-dsl/src/test/kotlin/fr/enedis/chutney/kotlin/synchronize/EnvironmentServiceSynchronizationTest.kt
+++ b/kotlin-dsl/src/test/kotlin/fr/enedis/chutney/kotlin/synchronize/EnvironmentServiceSynchronizationTest.kt
@@ -42,7 +42,7 @@ class EnvironmentServiceSynchronizationTest : HttpTestBase() {
                     ]
                     """.trimIndent()
         stubFor(
-            get(urlEqualTo("/api/v2/environment"))
+            get(urlEqualTo("/api/v2/environments"))
                 .willReturn(
                     aResponse()
                         .withStatus(200)

--- a/kotlin-dsl/src/test/kotlin/fr/enedis/chutney/kotlin/synchronize/server/EnvironmentsTest.kt
+++ b/kotlin-dsl/src/test/kotlin/fr/enedis/chutney/kotlin/synchronize/server/EnvironmentsTest.kt
@@ -16,7 +16,7 @@ class EnvironmentsTest : ChutneyServerServiceImplTest() {
     @Test
     fun get_environments() {
         wireMockServer.stubFor(
-            get(urlPathMatching("/api/v2/environment"))
+            get(urlPathMatching("/api/v2/environments"))
                 .willReturn(
                     okJson("[]")
                 )
@@ -26,7 +26,7 @@ class EnvironmentsTest : ChutneyServerServiceImplTest() {
 
         wireMockServer.verify(
             1,
-            getRequestedFor(urlPathMatching("/api/v2/environment"))
+            getRequestedFor(urlPathMatching("/api/v2/environments"))
         )
         Assertions.assertThat(environments).isEmpty()
     }


### PR DESCRIPTION
<!--
  ~ SPDX-FileCopyrightText: 2017-2024 Enedis
  ~
  ~ SPDX-License-Identifier: Apache-2.0
  ~
  -->

#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made
Adds an API key authentication for kotlin-dsl synchronisation
The API keys are given to users as personal access tokens
A dedicated API is created to generate the tokens

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->
NA

#### Test plan <!-- OPTIONAL -->
Generate a personal access token using the API
Execute synchronisation by providing the token as API key

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
