### PR TITLE
Keep HTTP header outputs indexable in SpEL

### DIFF
--- a/chutney/action-impl/src/main/java/fr/enedis/chutney/action/http/domain/HttpAction.java
+++ b/chutney/action-impl/src/main/java/fr/enedis/chutney/action/http/domain/HttpAction.java
@@ -13,8 +13,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.ResourceAccessException;
 
 public class HttpAction {
@@ -35,9 +33,7 @@ public class HttpAction {
         Map<String, Object> outputs = new HashMap<>();
         outputs.put("status", response.getStatusCode().value());
         outputs.put("body", response.getBody());
-        MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
-        response.getHeaders().forEach(headers::put);
-        outputs.put("headers", headers);
+        outputs.put("headers", new HttpResponseHeaders(response.getHeaders()));
         return outputs;
     }
 }

--- a/chutney/action-impl/src/main/java/fr/enedis/chutney/action/http/domain/HttpAction.java
+++ b/chutney/action-impl/src/main/java/fr/enedis/chutney/action/http/domain/HttpAction.java
@@ -13,6 +13,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.ResourceAccessException;
 
 public class HttpAction {
@@ -33,7 +35,9 @@ public class HttpAction {
         Map<String, Object> outputs = new HashMap<>();
         outputs.put("status", response.getStatusCode().value());
         outputs.put("body", response.getBody());
-        outputs.put("headers", response.getHeaders());
+        MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+        response.getHeaders().forEach(headers::put);
+        outputs.put("headers", headers);
         return outputs;
     }
 }

--- a/chutney/action-impl/src/main/java/fr/enedis/chutney/action/http/domain/HttpResponseHeaders.java
+++ b/chutney/action-impl/src/main/java/fr/enedis/chutney/action/http/domain/HttpResponseHeaders.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2026 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.action.http.domain;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * HTTP response headers, as exposed to scenarios through the {@code headers} action output.
+ *
+ * <p>Until Spring Framework 7, {@link HttpHeaders} implemented {@link MultiValueMap}. Scenarios could
+ * therefore both index headers by name, as in {@code ${#headers['set-cookie'][0]}}, and call the typed
+ * getters, as in {@code ${#headers.getContentType()}}. Spring 7 removed that interface: indexing then
+ * failed with {@code EL1027E} and execution reports serialized headers as a bean rather than a map.
+ *
+ * <p>This type restores both usages by extending {@link HttpHeaders} and implementing the {@link Map}
+ * contract on top of {@link HttpHeaders#headerSet()} and {@link HttpHeaders#headerNames()}, which are
+ * case-insensitive views over the headers Spring already holds. Lookup therefore stays case-insensitive:
+ * {@code #headers['Set-Cookie']} and {@code #headers['set-cookie']} resolve alike.
+ *
+ * <p>Map access is the preferred form. The typed getters are kept only so that scenarios written before
+ * the Spring 7 upgrade keep working, and are expected to be dropped once a major version allows it.
+ */
+public class HttpResponseHeaders extends HttpHeaders implements MultiValueMap<String, String> {
+
+    public HttpResponseHeaders(HttpHeaders headers) {
+        super(headers);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return key instanceof String name && containsHeader(name);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return headerSet().stream().anyMatch(header -> header.getValue().equals(value));
+    }
+
+    @Override
+    public List<String> get(Object key) {
+        return key instanceof String name ? super.get(name) : null;
+    }
+
+    @Override
+    public List<String> remove(Object key) {
+        return key instanceof String name ? super.remove(name) : null;
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return headerNames();
+    }
+
+    @Override
+    public Collection<List<String>> values() {
+        return headerSet().stream().map(Map.Entry::getValue).toList();
+    }
+
+    @Override
+    public Set<Map.Entry<String, List<String>>> entrySet() {
+        return headerSet();
+    }
+
+    @Override
+    public void addAll(MultiValueMap<String, String> other) {
+        other.forEach(super::addAll);
+    }
+}

--- a/chutney/action-impl/src/test/java/fr/enedis/chutney/action/http/HttpActionTest.java
+++ b/chutney/action-impl/src/test/java/fr/enedis/chutney/action/http/HttpActionTest.java
@@ -41,14 +41,19 @@ import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import tools.jackson.databind.json.JsonMapper;
 
 
 public class HttpActionTest {
@@ -160,6 +165,75 @@ public class HttpActionTest {
         assertThat((Integer) executionResult.outputs.get("status")).isEqualTo(expectedStatus);
         assertThat((String) executionResult.outputs.get("body")).isEqualTo(expectedBody);
         assertThat((MultiValueMap<String, String>) executionResult.outputs.get("headers")).containsAllEntriesOf(expectedHeaders);
+    }
+
+    @Nested
+    @DisplayName("Response headers output")
+    class ResponseHeadersOutput {
+
+        @Test
+        public void should_be_indexable_by_header_name_whatever_its_case() {
+            // given
+            String uri = "/some/thing";
+            stubFor(get(urlEqualTo(uri))
+                .willReturn(aResponse().withStatus(200)
+                    .withHeader("Set-Cookie", "JSESSIONID=1234")
+                    .withBody("Resource Body"))
+            );
+
+            // when
+            Action httpGetAction = new HttpGetAction(mockTarget("http://127.0.0.1:" + wireMockServer.port()), mock(Logger.class), uri, null, "1000 ms");
+            ActionExecutionResult executionResult = httpGetAction.execute();
+
+            // then
+            Map<String, List<String>> headers = (Map<String, List<String>>) executionResult.outputs.get("headers");
+            assertThat(headers.get("Set-Cookie")).containsExactly("JSESSIONID=1234");
+            assertThat(headers.get("set-cookie")).containsExactly("JSESSIONID=1234");
+            assertThat(headers.get("SET-COOKIE")).containsExactly("JSESSIONID=1234");
+        }
+
+        @Test
+        public void should_still_expose_spring_typed_getters() {
+            // given
+            String uri = "/some/thing";
+            stubFor(get(urlEqualTo(uri))
+                .willReturn(aResponse().withStatus(200)
+                    .withHeader("Content-Type", "application/zip")
+                    .withHeader("Content-Disposition", "attachment; filename=\"surefire-report.zip\"")
+                    .withBody("Resource Body"))
+            );
+
+            // when
+            Action httpGetAction = new HttpGetAction(mockTarget("http://127.0.0.1:" + wireMockServer.port()), mock(Logger.class), uri, null, "1000 ms");
+            ActionExecutionResult executionResult = httpGetAction.execute();
+
+            // then
+            HttpHeaders headers = (HttpHeaders) executionResult.outputs.get("headers");
+            assertThat(headers.getContentType()).hasToString("application/zip");
+            assertThat(headers.getContentDisposition().getFilename()).isEqualTo("surefire-report.zip");
+            assertThat(headers.getFirst("Content-Type")).isEqualTo("application/zip");
+        }
+
+        @Test
+        public void should_be_serialized_as_a_flat_map_in_execution_reports() {
+            // given
+            String uri = "/some/thing";
+            stubFor(get(urlEqualTo(uri))
+                .willReturn(aResponse().withStatus(200)
+                    .withHeader("Content-Type", "application/zip")
+                    .withBody("Resource Body"))
+            );
+
+            // when
+            Action httpGetAction = new HttpGetAction(mockTarget("http://127.0.0.1:" + wireMockServer.port()), mock(Logger.class), uri, null, "1000 ms");
+            ActionExecutionResult executionResult = httpGetAction.execute();
+
+            // then
+            String report = JsonMapper.builder().build().writeValueAsString(executionResult.outputs.get("headers"));
+            assertThat(report)
+                .contains("\"Content-Type\":[\"application/zip\"]")
+                .doesNotContain("acceptCharset");
+        }
     }
 
     @Test

--- a/chutney/action-impl/src/test/java/fr/enedis/chutney/action/http/HttpActionTest.java
+++ b/chutney/action-impl/src/test/java/fr/enedis/chutney/action/http/HttpActionTest.java
@@ -26,16 +26,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import fr.enedis.chutney.action.TestTarget;
 import fr.enedis.chutney.action.spi.Action;
 import fr.enedis.chutney.action.spi.ActionExecutionResult;
 import fr.enedis.chutney.action.spi.injectable.Logger;
 import fr.enedis.chutney.action.spi.injectable.Target;
 import fr.enedis.chutney.tools.SocketUtils;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.http.Fault;
-import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
@@ -47,7 +47,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.http.HttpHeaders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 
 public class HttpActionTest {
@@ -139,7 +140,7 @@ public class HttpActionTest {
         String uri = "/some/thing";
         int expectedStatus = 200;
         String expectedBody = "Resource Body";
-        org.springframework.http.HttpHeaders expectedHeaders = new org.springframework.http.HttpHeaders();
+        MultiValueMap<String, String> expectedHeaders = new LinkedMultiValueMap<>();
         expectedHeaders.put("Transfer-Encoding", Collections.singletonList("chunked"));
 
         stubFor(get(urlEqualTo(uri))
@@ -158,7 +159,7 @@ public class HttpActionTest {
         assertThat(executionResult.status).isEqualTo(ActionExecutionResult.Status.Success);
         assertThat((Integer) executionResult.outputs.get("status")).isEqualTo(expectedStatus);
         assertThat((String) executionResult.outputs.get("body")).isEqualTo(expectedBody);
-        assertThat(((HttpHeaders) executionResult.outputs.get("headers")).asMultiValueMap()).containsAllEntriesOf(expectedHeaders.asMultiValueMap());
+        assertThat((MultiValueMap<String, String>) executionResult.outputs.get("headers")).containsAllEntriesOf(expectedHeaders);
     }
 
     @Test

--- a/docs/docs/documentation/actions/http.md
+++ b/docs/docs/documentation/actions/http.md
@@ -32,6 +32,23 @@
             * Default port value is 3128.
             * Target property `proxy` override system property if set
 
+!!! note "How to read response headers"
+
+    For all HTTP actions, the `headers` output holds the response headers as a multi-valued map.
+    A header may legally appear more than once, so each name maps to a list of values.
+
+    Header names are case-insensitive, so `#headers['Set-Cookie']` and `#headers['set-cookie']` are equivalent.
+
+    ```
+    ${#headers['Set-Cookie'][0]}        first value, indexed by name (preferred)
+    ${#headers.getFirst('Set-Cookie')}  first value, equivalent
+    ${#headers['Set-Cookie']}           every value, as a list
+    ```
+
+    Spring's typed getters, such as `${#headers.getContentType()}`, remain available for scenarios
+    written before Chutney 4.3.0, but map access is preferred and typed getters may be removed in a
+    future major version.
+
 
 ```json title="Http target example"
 {

--- a/docs/docs/documentation/actions/introduction.md
+++ b/docs/docs/documentation/actions/introduction.md
@@ -115,6 +115,8 @@ After executing this action, the execution context will contain the following ou
 Your relevant data can be accessed from another SpEL using `#bestMovies` and since it is a List you can call methods on it, like so : `${#bestMovies.get(0)}`  
 `#body`, `#status` and `#headers` are also available but are very likely to be overridden by a following step while you have full control over the use of the `#bestMovies` key.
 
+`#headers` is a multi-valued map keyed by header name, so a single value is read with `${#headers['Content-Type'][0]}`. Names are case-insensitive. See [HTTP actions](http.md) for details.
+
 # Validations
 
 Validations are a list of checks you want to perform in order to validate a step.

--- a/docs/docs/documentation/actions/soap.md
+++ b/docs/docs/documentation/actions/soap.md
@@ -27,6 +27,9 @@
     |    `body` | String                                                                                                                                      |
     | `headers` | [HttpHeaders](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/HttpHeaders.html){:target="_blank"} |
 
+    Response headers are read as a case-insensitive multi-valued map, e.g. `${#headers['Content-Type'][0]}`.
+    See [HTTP actions](http.md) for details.
+
 ### Example
 
 === "Kotlin"

--- a/kotlin-dsl/src/main/kotlin/fr/enedis/chutney/kotlin/dsl/ChutneyActionExtensions.kt
+++ b/kotlin-dsl/src/main/kotlin/fr/enedis/chutney/kotlin/dsl/ChutneyActionExtensions.kt
@@ -513,7 +513,7 @@ fun ChutneyStepBuilder.MongoListAction(
  * Outputs:
  * - status : http response status (int)
  * - body : http response body (String)
- * - headers : http response headers (org.springframework.http.HttpHeaders)
+ * - headers : http response headers, as a case-insensitive multi-valued map, e.g. "headers['Set-Cookie'][0]".spEL()
  */
 fun ChutneyStepBuilder.HttpGetAction(
     target: String,
@@ -544,7 +544,7 @@ fun ChutneyStepBuilder.HttpGetAction(
  * Outputs:
  * - status : http response status (int)
  * - body : http response body (String)
- * - headers : http response headers (org.springframework.http.HttpHeaders)
+ * - headers : http response headers, as a case-insensitive multi-valued map, e.g. "headers['Set-Cookie'][0]".spEL()
  */
 fun ChutneyStepBuilder.HttpPostAction(
     target: String,
@@ -583,7 +583,7 @@ fun ChutneyStepBuilder.HttpPostAction(
  * Outputs:
  * - status : http response status (int)
  * - body : http response body (String)
- * - headers : http response headers (org.springframework.http.HttpHeaders)
+ * - headers : http response headers, as a case-insensitive multi-valued map, e.g. "headers['Set-Cookie'][0]".spEL()
  */
 fun ChutneyStepBuilder.HttpPutAction(
     target: String,
@@ -616,7 +616,7 @@ fun ChutneyStepBuilder.HttpPutAction(
  * Outputs:
  * - status : http response status (int)
  * - body : http response body (String)
- * - headers : http response headers (org.springframework.http.HttpHeaders)
+ * - headers : http response headers, as a case-insensitive multi-valued map, e.g. "headers['Set-Cookie'][0]".spEL()
  */
 fun ChutneyStepBuilder.HttpDeleteAction(
     target: String,
@@ -647,7 +647,7 @@ fun ChutneyStepBuilder.HttpDeleteAction(
  * Outputs:
  * - status : http response status (int)
  * - body : http response body (String)
- * - headers : http response headers (org.springframework.http.HttpHeaders)
+ * - headers : http response headers, as a case-insensitive multi-valued map, e.g. "headers['Set-Cookie'][0]".spEL()
  */
 fun ChutneyStepBuilder.HttpSoapAction(
     target: String,
@@ -684,7 +684,7 @@ fun ChutneyStepBuilder.HttpSoapAction(
  * Outputs:
  * - status : http response status (int)
  * - body : http response body (String)
- * - headers : http response headers (org.springframework.http.HttpHeaders)
+ * - headers : http response headers, as a case-insensitive multi-valued map, e.g. "headers['Set-Cookie'][0]".spEL()
  */
 fun ChutneyStepBuilder.HttpPatchAction(
     target: String,


### PR DESCRIPTION
#### Issue Number
fixes #392 
#### Describe the changes you've made

Since 4.3.0 (Spring Framework 7), `HttpHeaders` no longer implements `MultiValueMap`, so
`${#headers['set-cookie'][0]}` fails with `EL1027E`. Headers also show up as a bean instead of a flat
`name -> [values]` map in execution reports.

The `headers` output is now `HttpResponseHeaders`, which extends `HttpHeaders` and implements
`MultiValueMap`, so both styles keep working:

```
${#headers['Set-Cookie'][0]}    fixed (any casing)
${#headers.getContentType()}    unchanged
```

No existing scenario or test needed changes, `CampaignAcceptanceTest` passes as it is.

#### Additional context

Affects all HTTP verbs and SOAP, they share `HttpAction.toOutputs`.

Tests added: indexing with different casing, typed getters still working, flat map in the report.

#### Checklist

- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
