### PR TITLE
Prevent execution report step list from scrolling on mouse m…

### DIFF
--- a/chutney/ui/src/app/shared/components/scenario-execution/execution.component.ts
+++ b/chutney/ui/src/app/shared/components/scenario-execution/execution.component.ts
@@ -84,6 +84,7 @@ export class ScenarioExecutionComponent implements OnInit, OnDestroy, AfterViewI
     collapseDataset = true;
 
     private scenarioExecutionAsyncSubscription: Subscription;
+    private leftPanelPositionSubscription: Subscription;
     private unsubscribeSub$: Subject<void> = new Subject();
 
     @ViewChild('leftPanel') leftPanel;
@@ -94,6 +95,8 @@ export class ScenarioExecutionComponent implements OnInit, OnDestroy, AfterViewI
     private stickyTopElement: HTMLElement;
     private stickyTopElementHeight: number = 0;
     private stickyTopElementResizeObserver: ResizeObserver;
+    private reportHeaderResizeObserver: ResizeObserver;
+    private initializedLeftPanel: HTMLElement;
 
     constructor(
         private scenarioExecutionService: ScenarioExecutionService,
@@ -115,20 +118,9 @@ export class ScenarioExecutionComponent implements OnInit, OnDestroy, AfterViewI
     }
 
     ngAfterViewInit(): void {
-        if(this.leftPanel) {
-            merge(
-                fromEvent(window, 'resize'),
-                fromEvent(findScrollContainer(this.leftPanel.nativeElement),'scroll')
-            ).pipe(
-                takeUntil(this.unsubscribeSub$),
-                throttleTime(150),
-                debounceTime(150)
-            ).subscribe(() => {
-                this.setLeftPanelStyle();
-            });
-        }
-
         this.setReportHeaderTop();
+        this.reportHeaderResizeObserver = new ResizeObserver(() => this.setLeftPanelStyle());
+        this.reportHeaderResizeObserver.observe(this.reportHeader.nativeElement);
 
         if (this.stickyTopElementSelector) {
             this.stickyTopElement = document.querySelector(this.stickyTopElementSelector) as HTMLElement;
@@ -154,11 +146,16 @@ export class ScenarioExecutionComponent implements OnInit, OnDestroy, AfterViewI
     }
 
     ngAfterViewChecked(): void {
-        this.setLeftPanelStyle();
+        const leftPanel = this.leftPanel?.nativeElement;
+        if (leftPanel && leftPanel !== this.initializedLeftPanel) {
+            this.initializeLeftPanel(leftPanel);
+        }
     }
 
     ngOnDestroy() {
         this.unsubscribeScenarioExecutionAsyncSubscription();
+        this.leftPanelPositionSubscription?.unsubscribe();
+        this.reportHeaderResizeObserver?.disconnect();
         if (this.stickyTopElementResizeObserver) this.stickyTopElementResizeObserver.unobserve(this.stickyTopElement);
         this.unsubscribeSub$.next();
         this.unsubscribeSub$.complete();
@@ -403,6 +400,20 @@ export class ScenarioExecutionComponent implements OnInit, OnDestroy, AfterViewI
     }
 
 ////////////////////////////////////////////////////// REPORT new view
+
+    private initializeLeftPanel(leftPanel: HTMLElement) {
+        this.initializedLeftPanel = leftPanel;
+        this.leftPanelPositionSubscription?.unsubscribe();
+        this.leftPanelPositionSubscription = merge(
+            fromEvent(window, 'resize'),
+            fromEvent(findScrollContainer(leftPanel), 'scroll')
+        ).pipe(
+            takeUntil(this.unsubscribeSub$),
+            throttleTime(150),
+            debounceTime(150)
+        ).subscribe(() => this.setLeftPanelStyle());
+        this.setLeftPanelStyle();
+    }
 
     private setLeftPanelStyle() {
         if(this.leftPanel) {


### PR DESCRIPTION
Recalculate the execution report's left panel dimensions only when its
layout can actually change: initialization, scrolling, window resizing,
and header or sticky-element resizing.

This prevents Angular view checks triggered by mouse interactions from
altering the panel height and unexpectedly moving the page when the
right-hand report is scrolled to the bottom.

Existing scrolling behavior for failed and explicitly selected steps is
preserved.

<!--
  ~ SPDX-FileCopyrightText: 2017-2026 Enedis
  ~
  ~ SPDX-License-Identifier: Apache-2.0
  ~
  -->

#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made

<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [ ] All new and existing tests pass
- [ ] No git conflict
