### PR TITLE
Preserve failed execution data and navigation on replay

### DIFF
--- a/chutney/server-core/src/main/java/fr/enedis/chutney/server/core/domain/execution/ScenarioExecutionEngineAsync.java
+++ b/chutney/server-core/src/main/java/fr/enedis/chutney/server/core/domain/execution/ScenarioExecutionEngineAsync.java
@@ -25,6 +25,7 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -128,7 +129,7 @@ public class ScenarioExecutionEngineAsync {
             followResult = executionEngine.executeAndFollow(executionRequest);
         } catch (Exception e) {
             LOGGER.error("Cannot execute test case [" + executionRequest.testCase.id() + "]", e.getMessage());
-            setExecutionToFailed(executionRequest.testCase.id(), storedExecution, ofNullable(e.getMessage()).orElse(e.toString()));
+            setExecutionToFailed(executionRequest, storedExecution, ofNullable(e.getMessage()).orElse(e.toString()));
             throw new FailedExecutionAttempt(e, storedExecution.executionId(), executionRequest.testCase.metadata().title());
         }
         return followResult;
@@ -181,11 +182,48 @@ public class ScenarioExecutionEngineAsync {
             .autoConnect();
     }
 
-    private void setExecutionToFailed(String scenarioId, ExecutionHistory.Execution storedExecution, String errorMessage) {
-        ImmutableExecutionHistory.Execution execution = ImmutableExecutionHistory.Execution.copyOf(storedExecution)
-            .withStatus(ServerReportStatus.FAILURE)
-            .withError(errorMessage);
-        executionHistoryRepository.update(scenarioId, execution);
+    private void setExecutionToFailed(ExecutionRequest executionRequest, ExecutionHistory.Execution storedExecution, String errorMessage) {
+        Instant failureDate = Instant.now();
+        StepExecutionReportCore failedStepReport = new StepExecutionReportCore(
+            executionRequest.testCase.metadata().title(),
+            0L,
+            failureDate,
+            ServerReportStatus.FAILURE,
+            emptyList(),
+            List.of(errorMessage),
+            emptyList(),
+            null,
+            null,
+            null,
+            null
+        );
+        StepExecutionReportCore failureReport = new StepExecutionReportCore(
+            executionRequest.testCase.metadata().title(),
+            0L,
+            failureDate,
+            ServerReportStatus.FAILURE,
+            emptyList(),
+            emptyList(),
+            List.of(failedStepReport),
+            null,
+            null,
+            null,
+            null
+        );
+        ScenarioExecutionReport scenarioExecutionReport = new ScenarioExecutionReport(
+            storedExecution.executionId(),
+            executionRequest.testCase.metadata().title(),
+            executionRequest.environment,
+            executionRequest.userId,
+            executionRequest.tags,
+            executionRequest.dataset,
+            failureReport
+        );
+        executionHistoryRepository.update(
+            executionRequest.testCase.id(),
+            reportSummarizer.summarize(scenarioExecutionReport, executionRequest)
+                .attach(storedExecution.executionId(), executionRequest.testCase.id())
+        );
     }
 
 

--- a/chutney/server-core/src/test/java/fr/enedis/chutney/server/core/domain/execution/ScenarioExecutionEngineAsyncTest.java
+++ b/chutney/server-core/src/test/java/fr/enedis/chutney/server/core/domain/execution/ScenarioExecutionEngineAsyncTest.java
@@ -123,6 +123,42 @@ public class ScenarioExecutionEngineAsyncTest {
     }
 
     @Test
+    public void should_store_custom_dataset_in_report_when_engine_fails_before_execution_starts() throws Exception {
+        TestCase testCase = emptyTestCase();
+        long executionId = 42L;
+        stubHistoryExecution(testCase.id(), executionId);
+        when(executionEngine.executeAndFollow(any())).thenThrow(new IllegalArgumentException("Target not found"));
+        ScenarioExecutionEngineAsync sut = new ScenarioExecutionEngineAsync(
+            executionHistoryRepository,
+            executionEngine,
+            executionStateRepository,
+            metrics,
+            om
+        );
+        DataSet customDataset = DataSet.builder()
+            .withName("")
+            .withConstants(Map.of("constant", "value"))
+            .withDatatable(List.of(Map.of("column", "cell")))
+            .build();
+
+        assertThatThrownBy(() -> sut.execute(new ExecutionRequest(testCase, "env", "user", customDataset)))
+            .isInstanceOf(FailedExecutionAttempt.class);
+
+        ArgumentCaptor<ExecutionHistory.Execution> executionCaptor = ArgumentCaptor.forClass(ExecutionHistory.Execution.class);
+        verify(executionHistoryRepository).update(eq(testCase.id()), executionCaptor.capture());
+        ExecutionHistory.Execution failedExecution = executionCaptor.getValue();
+        ScenarioExecutionReport persistedReport = om.readValue(failedExecution.report(), ScenarioExecutionReport.class);
+        assertThat(failedExecution.status()).isEqualTo(ServerReportStatus.FAILURE);
+        assertThat(persistedReport.constants).containsEntry("constant", "value");
+        assertThat(persistedReport.datatable).containsExactly(Map.of("column", "cell"));
+        assertThat(persistedReport.report.errors).isEmpty();
+        assertThat(persistedReport.report.steps).singleElement().satisfies(step -> {
+            assertThat(step.status).isEqualTo(ServerReportStatus.FAILURE);
+            assertThat(step.errors).containsExactly("Target not found");
+        });
+    }
+
+    @Test
     public void should_send_reports_and_update_history_and_send_metrics_and_notify_startend_when_observe_engine_execution() {
         // Given
         final TestCase testCase = emptyTestCase();

--- a/chutney/server/src/main/java/fr/enedis/chutney/execution/api/ScenarioExecutionUiController.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/execution/api/ScenarioExecutionUiController.java
@@ -20,6 +20,7 @@ import fr.enedis.chutney.scenario.domain.gwt.GwtTestCase;
 import fr.enedis.chutney.security.infra.SpringUserService;
 import fr.enedis.chutney.server.core.domain.dataset.DataSet;
 import fr.enedis.chutney.server.core.domain.execution.ExecutionRequest;
+import fr.enedis.chutney.server.core.domain.execution.FailedExecutionAttempt;
 import fr.enedis.chutney.server.core.domain.execution.ScenarioExecutionEngine;
 import fr.enedis.chutney.server.core.domain.execution.ScenarioExecutionEngineAsync;
 import fr.enedis.chutney.server.core.domain.execution.report.ScenarioExecutionReport;
@@ -115,7 +116,13 @@ public class ScenarioExecutionUiController {
         TestCase testCase = testCaseRepository.findExecutableById(scenarioId).orElseThrow(() -> new ScenarioNotFoundException(scenarioId));
         String userId = userService.currentUserId();
         DataSet execDataset = getDataSet(dataset, testCase);
-        return executionEngineAsync.execute(new ExecutionRequest(testCase, env, userId, execDataset)).toString();
+        try {
+            return executionEngineAsync.execute(new ExecutionRequest(testCase, env, userId, execDataset)).toString();
+        } catch (FailedExecutionAttempt e) {
+            // The execution was created and its failure report was persisted before the engine could start.
+            // Returning its id lets asynchronous clients display it like any other completed execution.
+            return e.executionId.toString();
+        }
     }
 
     @PreAuthorize("hasAuthority('EXECUTION_WRITE')")

--- a/chutney/server/src/main/java/fr/enedis/chutney/execution/domain/campaign/CampaignExecutionEngine.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/execution/domain/campaign/CampaignExecutionEngine.java
@@ -380,6 +380,7 @@ public class CampaignExecutionEngine {
     private DataSet resolveScenarioDataset(Campaign.CampaignScenario campaignScenario, CampaignExecution campaignExecution) {
         return
             ofNullable(campaignScenario.datasetId())
+                .filter(datasetId -> !DataSet.CUSTOM_ID.equals(datasetId))
                 .map(datasetId -> DataSet.builder().withId(datasetId).withName("").build())
                 .or(() -> ofNullable(campaignExecution.dataset))
                 .map(ds -> {

--- a/chutney/server/src/test/java/fr/enedis/chutney/execution/api/ScenarioExecutionUiControllerTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/execution/api/ScenarioExecutionUiControllerTest.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2026 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.execution.api;
+
+import static java.util.Optional.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import fr.enedis.chutney.dataset.domain.DataSetRepository;
+import fr.enedis.chutney.environment.api.environment.EmbeddedEnvironmentApi;
+import fr.enedis.chutney.scenario.domain.gwt.GwtTestCase;
+import fr.enedis.chutney.security.infra.SpringUserService;
+import fr.enedis.chutney.server.core.domain.execution.FailedExecutionAttempt;
+import fr.enedis.chutney.server.core.domain.execution.ScenarioExecutionEngine;
+import fr.enedis.chutney.server.core.domain.execution.ScenarioExecutionEngineAsync;
+import fr.enedis.chutney.server.core.domain.scenario.TestCaseMetadataImpl;
+import fr.enedis.chutney.server.core.domain.scenario.TestCaseRepository;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class ScenarioExecutionUiControllerTest {
+
+    @Test
+    void should_return_created_execution_id_when_engine_fails_before_starting() {
+        ScenarioExecutionEngineAsync executionEngineAsync = mock(ScenarioExecutionEngineAsync.class);
+        TestCaseRepository testCaseRepository = mock(TestCaseRepository.class);
+        SpringUserService userService = mock(SpringUserService.class);
+        GwtTestCase testCase = GwtTestCase.builder()
+            .withMetadata(TestCaseMetadataImpl.builder().withId("123100").withTitle("scenario").build())
+            .build();
+        when(testCaseRepository.findExecutableById("123100")).thenReturn(of(testCase));
+        when(userService.currentUserId()).thenReturn("user");
+        when(executionEngineAsync.execute(any()))
+            .thenThrow(new FailedExecutionAttempt(new IllegalArgumentException("Target not found"), 13L, "scenario"));
+        ScenarioExecutionUiController sut = new ScenarioExecutionUiController(
+            mock(ScenarioExecutionEngine.class),
+            executionEngineAsync,
+            testCaseRepository,
+            mock(ObjectMapper.class),
+            userService,
+            mock(DataSetRepository.class),
+            mock(ScenarioExecutionReportMapper.class),
+            mock(EmbeddedEnvironmentApi.class)
+        );
+
+        String executionId = sut.executeScenarioAsyncWithExecutionParameters("123100", "DEMO", null);
+
+        assertThat(executionId).isEqualTo("13");
+    }
+}

--- a/chutney/server/src/test/java/fr/enedis/chutney/execution/domain/campaign/CampaignExecutionEngineTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/execution/domain/campaign/CampaignExecutionEngineTest.java
@@ -185,6 +185,33 @@ public class CampaignExecutionEngineTest {
     }
 
     @Test
+    public void replay_failed_scenario_with_custom_dataset_content() {
+        Campaign campaign = createCampaign(List.of(secondTestCase));
+        DataSet customDataset = DataSet.builder()
+            .withId(DataSet.CUSTOM_ID)
+            .withName("")
+            .withConstants(Map.of("constant", "value"))
+            .withDatatable(List.of(Map.of("column", "cell")))
+            .build();
+        ExecutionHistory.Execution failedExecution = ImmutableExecutionHistory.Execution
+            .copyOf(createExecution(secondTestCase.id(), secondScenarioExecutionId, FAILURE))
+            .withDataset(Optional.of(customDataset));
+
+        sut.executeScenarioInCampaign(
+            singletonList(new ScenarioExecutionCampaign(secondTestCase.id(), secondTestCase.metadata.title, failedExecution.summary())),
+            campaign,
+            "user",
+            customDataset,
+            null
+        );
+
+        ArgumentCaptor<ExecutionRequest> requestCaptor = ArgumentCaptor.forClass(ExecutionRequest.class);
+        verify(scenarioExecutionEngine).execute(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().dataset.constants).containsEntry("constant", "value");
+        assertThat(requestCaptor.getValue().dataset.datatable).containsExactly(Map.of("column", "cell"));
+    }
+
+    @Test
     public void stop_execution_of_scenarios_when_requested() {
         // Given
         Campaign campaign = createCampaign(List.of(firstTestCase, secondTestCase));


### PR DESCRIPTION
Persist reports and custom datasets when execution fails before starting. Return the failed execution ID from the async endpoint. Preserve execution tab query parameters for callback-only menu actions.

<!--
  ~ SPDX-FileCopyrightText: 2017-2026 Enedis
  ~
  ~ SPDX-License-Identifier: Apache-2.0
  ~
  -->

#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made

<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [ ] All new and existing tests pass
- [ ] No git conflict
