### PR TITLE
Allow overriding Chutney runtime configuration on docker

### DIFF
--- a/chutney/.docker/Dockerfile
+++ b/chutney/.docker/Dockerfile
@@ -3,12 +3,9 @@
 
 FROM eclipse-temurin:21-jre
 
-VOLUME /.chutney
-EXPOSE 8443
-
 LABEL org.opencontainers.image.source=https://github.com/Enedis-OSS/chutney
 
 ARG JAR_PATH=server/target
-COPY $JAR_PATH/chutney-server-*-boot.jar app.jar
+COPY $JAR_PATH/chutney-server-*-boot.jar /app.jar
 
-CMD ["java", "-jar", "/app.jar", "--server.port=8443", "--chutney.workspace=/.chutney"]
+ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
Use an entrypoint without hard-coded Spring Boot arguments. Remove fixed port and volume metadata so deployments can configure the server port and workspace at runtime.

<!--
  ~ SPDX-FileCopyrightText: 2017-2026 Enedis
  ~
  ~ SPDX-License-Identifier: Apache-2.0
  ~
  -->

#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made

<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [ ] All new and existing tests pass
- [ ] No git conflict
