### PR TITLE
Preserve selected execution step during retry refresh

### DIFF
--- a/chutney/ui/src/app/shared/components/scenario-execution/execution.component.spec.ts
+++ b/chutney/ui/src/app/shared/components/scenario-execution/execution.component.spec.ts
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2026 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { fakeAsync, tick } from '@angular/core/testing';
+
+import { ExecutionStatus } from '@core/model/scenario/execution-status';
+import { StepExecutionReport } from '@model';
+
+import { ScenarioExecutionComponent } from './execution.component';
+
+describe('ScenarioExecutionComponent', () => {
+    let component: ScenarioExecutionComponent;
+
+    beforeEach(() => {
+        component = new ScenarioExecutionComponent(
+            null, null, null, null, null, null, null
+        );
+    });
+
+    it('should automatically select the first failed step on initial report display', fakeAsync(() => {
+        const failedStep = step('failed', ExecutionStatus.FAILURE);
+        setReport([failedStep]);
+        spyOn(component, 'selectStep');
+
+        component['afterReportUpdate']();
+        tick(500);
+
+        expect(component.selectStep).toHaveBeenCalledOnceWith(failedStep, true);
+    }));
+
+    it('should preserve a manually selected sub-step during retry refresh', fakeAsync(() => {
+        const selectedSubStep = step('selected', ExecutionStatus.SUCCESS);
+        const retryStep = step('retry', ExecutionStatus.FAILURE, [selectedSubStep]);
+        setReport([retryStep]);
+        component.selectStep(selectedSubStep);
+        spyOn(component, 'selectStep').and.callThrough();
+
+        component['afterReportUpdate']();
+        tick(500);
+
+        expect(component.selectedStep).toBe(selectedSubStep);
+        expect(component.selectStep).not.toHaveBeenCalled();
+    }));
+
+    it('should not override a selection made while failed-step selection is pending', fakeAsync(() => {
+        const failedStep = step('failed', ExecutionStatus.FAILURE);
+        const manuallySelectedStep = step('manually selected', ExecutionStatus.SUCCESS);
+        setReport([failedStep, manuallySelectedStep]);
+
+        component['afterReportUpdate']();
+        component.selectStep(manuallySelectedStep);
+        tick(500);
+
+        expect(component.selectedStep).toBe(manuallySelectedStep);
+    }));
+
+    it('should preserve an explicit root selection during retry refresh', fakeAsync(() => {
+        setReport([step('retry', ExecutionStatus.FAILURE)]);
+        component.selectStep();
+        spyOn(component, 'selectStep').and.callThrough();
+
+        component['afterReportUpdate']();
+        tick(500);
+
+        expect(component.selectedStep).toBeNull();
+        expect(component.selectStep).not.toHaveBeenCalled();
+    }));
+
+    it('should restore the selected step from a replaced report tree', () => {
+        const previousSelectedStep = step('selected before refresh', ExecutionStatus.RUNNING);
+        previousSelectedStep['rowId'] = '0-0';
+        component.selectedStep = previousSelectedStep;
+        const refreshedSelectedStep = step('selected after refresh', ExecutionStatus.SUCCESS);
+        setReport([step('retry', ExecutionStatus.RUNNING, [refreshedSelectedStep])]);
+
+        component['afterReportUpdate']();
+
+        expect(component.selectedStep).toBe(refreshedSelectedStep);
+    });
+
+    function setReport(steps: StepExecutionReport[]) {
+        component.scenarioExecutionReport = {
+            contextVariables: {},
+            report: { steps }
+        } as any;
+    }
+
+    function step(name: string, status: ExecutionStatus, steps: StepExecutionReport[] = []): StepExecutionReport {
+        return { name, status, steps } as StepExecutionReport;
+    }
+});

--- a/chutney/ui/src/app/shared/components/scenario-execution/execution.component.ts
+++ b/chutney/ui/src/app/shared/components/scenario-execution/execution.component.ts
@@ -191,7 +191,10 @@ export class ScenarioExecutionComponent implements OnInit, OnDestroy, AfterViewI
     private afterReportUpdate() {
         this.hasContextVariables = this.scenarioExecutionReport.contextVariables && Object.getOwnPropertyNames(this.scenarioExecutionReport.contextVariables).length > 0;
         this.computeAllStepRowId();
-        this.selectFailedStep();
+        this.restoreSelectedStep();
+        if (this.selectedStep === undefined) {
+            this.selectFailedStep();
+        }
     }
 
     private selectFailedStep() {
@@ -199,8 +202,35 @@ export class ScenarioExecutionComponent implements OnInit, OnDestroy, AfterViewI
         if (failedStep?.length > 0) {
             timer(500)
                 .pipe(takeUntil(this.unsubscribeSub$))
-                .subscribe(() => this.selectStep(failedStep[0], true));
+                .subscribe(() => {
+                    if (this.selectedStep === undefined) {
+                        const currentFailedStep = this.getFailureSteps(this.scenarioExecutionReport)?.[0];
+                        if (currentFailedStep) {
+                            this.selectStep(currentFailedStep, true);
+                        }
+                    }
+                });
         }
+    }
+
+    private restoreSelectedStep() {
+        const selectedRowId = this.selectedStep?.['rowId'];
+        if (selectedRowId !== undefined) {
+            this.selectedStep = this.findStepByRowId(this.scenarioExecutionReport.report.steps, selectedRowId) ?? this.selectedStep;
+        }
+    }
+
+    private findStepByRowId(steps: StepExecutionReport[], rowId: string): StepExecutionReport | undefined {
+        for (const step of steps) {
+            if (step['rowId'] === rowId) {
+                return step;
+            }
+            const matchingSubStep = this.findStepByRowId(step.steps, rowId);
+            if (matchingSubStep) {
+                return matchingSubStep;
+            }
+        }
+        return undefined;
     }
 
     protected getDataset(execution: ScenarioExecutionReport) {


### PR DESCRIPTION
Prevent real-time execution report updates from replacing the step selected by the user during retry attempts.

Only select the first failed step when no selection has been initialized, and restore the selected step by its row ID when the refreshed report replaces the execution tree.

Also prevent delayed failed-step selection from overriding a selection made in the meantime.

<!--
  ~ SPDX-FileCopyrightText: 2017-2026 Enedis
  ~
  ~ SPDX-License-Identifier: Apache-2.0
  ~
  -->

#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made

<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [ ] All new and existing tests pass
- [ ] No git conflict
