### PR TITLE
fix(ui): keep execution history refresh active after errors

### DIFF
--- a/chutney/ui/src/app/modules/scenarios/components/execution/history/scenario-executions-history.component.spec.ts
+++ b/chutney/ui/src/app/modules/scenarios/components/execution/history/scenario-executions-history.component.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2026 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { fakeAsync, tick } from '@angular/core/testing';
+import { defer, of, throwError } from 'rxjs';
+
+import { Execution } from '@model';
+import { ExecutionStatus } from '@core/model/scenario/execution-status';
+
+import { ScenarioExecutionsHistoryComponent } from './scenario-executions-history.component';
+
+describe('ScenarioExecutionsHistoryComponent', () => {
+    it('should keep refreshing after a transient error and stop when no execution is running', fakeAsync(() => {
+        const runningExecution = executionWithStatus(ExecutionStatus.RUNNING);
+        const completedExecution = executionWithStatus(ExecutionStatus.SUCCESS);
+        let requestCount = 0;
+        const scenarioExecutionService = jasmine.createSpyObj('ScenarioExecutionService', ['findScenarioExecutions']);
+        scenarioExecutionService.findScenarioExecutions.and.returnValue(defer(() =>
+            ++requestCount === 1
+                ? throwError(() => new Error('Temporary error'))
+                : of([completedExecution])
+        ));
+        const component = new ScenarioExecutionsHistoryComponent(
+            {} as any,
+            {} as any,
+            scenarioExecutionService,
+            {} as any,
+            {} as any,
+            {} as any
+        );
+        component.executions = [runningExecution];
+
+        (component as any).checkForRefresh();
+        expect(requestCount).toBe(1);
+
+        tick(5000);
+
+        expect(requestCount).toBe(2);
+        expect(component.executions).toEqual([completedExecution]);
+        expect((component as any).isRefreshActive()).toBeFalse();
+
+        tick(10000);
+        expect(requestCount).toBe(2);
+    }));
+});
+
+function executionWithStatus(status: ExecutionStatus): Execution {
+    return new Execution(0, status, null, 1, new Date(), null, null, null, []);
+}

--- a/chutney/ui/src/app/modules/scenarios/components/execution/history/scenario-executions-history.component.ts
+++ b/chutney/ui/src/app/modules/scenarios/components/execution/history/scenario-executions-history.component.ts
@@ -11,7 +11,7 @@ import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Dataset, Execution, GwtTestCase } from '@model';
 import { ScenarioExecutionService } from 'src/app/core/services/scenario-execution.service';
 import { NgbNavChangeEvent } from '@ng-bootstrap/ng-bootstrap';
-import { EMPTY, forkJoin, Observable, of, Subject, Subscription, throwError, zip, repeat } from 'rxjs';
+import { EMPTY, forkJoin, Observable, of, Subject, Subscription, throwError, zip, repeat, retry } from 'rxjs';
 import { ScenarioService } from '@core/services';
 import { ExecutionStatus } from '@core/model/scenario/execution-status';
 import { AlertService, EventManagerService } from '@shared';
@@ -300,6 +300,7 @@ export class ScenarioExecutionsHistoryComponent implements OnInit, OnDestroy {
             if (!this.isRefreshActive()) {
                 this.refreshSubscription = this.loadScenarioExecutions().pipe(
                     delay(5000),
+                    retry({ delay: 5000 }),
                     repeat()
                 ).subscribe();
             }


### PR DESCRIPTION
Retry scenario execution history polling after transient HTTP errors instead of permanently stopping the auto-refresh.

Keep the five-second polling interval and stop refreshing when no execution remains running.

Add a unit test covering retry recovery and polling termination.

<!--
  ~ SPDX-FileCopyrightText: 2017-2026 Enedis
  ~
  ~ SPDX-License-Identifier: Apache-2.0
  ~
  -->

#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made

<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [ ] All new and existing tests pass
- [ ] No git conflict
