### PR TITLE
fix(): report steps skipped by if strategy with a dedicated status

### DIFF
--- a/chutney/engine/src/main/java/fr/enedis/chutney/engine/api/execution/StatusDto.java
+++ b/chutney/engine/src/main/java/fr/enedis/chutney/engine/api/execution/StatusDto.java
@@ -8,5 +8,5 @@
 package fr.enedis.chutney.engine.api.execution;
 
 public enum StatusDto {
-    SUCCESS, WARN, FAILURE, NOT_EXECUTED, STOPPED, PAUSED, RUNNING, EXECUTED
+    SUCCESS, WARN, FAILURE, NOT_EXECUTED, STOPPED, PAUSED, RUNNING, EXECUTED, SKIPPED
 }

--- a/chutney/engine/src/main/java/fr/enedis/chutney/engine/domain/execution/engine/step/Step.java
+++ b/chutney/engine/src/main/java/fr/enedis/chutney/engine/domain/execution/engine/step/Step.java
@@ -195,6 +195,10 @@ public class Step {
         state.successOccurred(message);
     }
 
+    public void skipped(String... message) {
+        state.skippedOccurred(message);
+    }
+
     public void resetExecution() {
         state.reset();
         steps.forEach(Step::resetExecution);
@@ -265,7 +269,7 @@ public class Step {
     }
 
     public void updateContextFrom(StepExecutionReport remoteReport) {
-        ActionExecutionResult.Status status = Status.SUCCESS.equals(remoteReport.status) ? ActionExecutionResult.Status.Success : ActionExecutionResult.Status.Failure;
+        ActionExecutionResult.Status status = Status.SUCCESS.equals(remoteReport.status) || Status.SKIPPED.equals(remoteReport.status) ? ActionExecutionResult.Status.Success : ActionExecutionResult.Status.Failure;
         updateContextWith(status, remoteReport.stepResults, emptyList(), emptyList());
     }
 

--- a/chutney/engine/src/main/java/fr/enedis/chutney/engine/domain/execution/engine/step/StepState.java
+++ b/chutney/engine/src/main/java/fr/enedis/chutney/engine/domain/execution/engine/step/StepState.java
@@ -84,6 +84,11 @@ public class StepState {
         informations.addAll(newArrayList(message));
     }
 
+    void skippedOccurred(String... message) {
+        status = Status.SKIPPED;
+        informations.addAll(newArrayList(message));
+    }
+
     void reset() {
         status = Status.NOT_EXECUTED;
         informations.clear();

--- a/chutney/engine/src/main/java/fr/enedis/chutney/engine/domain/execution/report/Status.java
+++ b/chutney/engine/src/main/java/fr/enedis/chutney/engine/domain/execution/report/Status.java
@@ -12,18 +12,27 @@ import java.util.List;
 import java.util.Objects;
 
 public enum Status {
-    SUCCESS, WARN, FAILURE, NOT_EXECUTED, STOPPED, PAUSED, RUNNING, EXECUTED;
+    SUCCESS, WARN, FAILURE, NOT_EXECUTED, STOPPED, PAUSED, RUNNING, EXECUTED, SKIPPED;
 
-    private static final Ordering<Status> EXECUTION_STATUS_STATUS_ORDERING = Ordering.explicit(EXECUTED, PAUSED, RUNNING, STOPPED, FAILURE, WARN, NOT_EXECUTED, SUCCESS);
+    private static final Ordering<Status> EXECUTION_STATUS_STATUS_ORDERING = Ordering.explicit(EXECUTED, PAUSED, RUNNING, STOPPED, FAILURE, WARN, NOT_EXECUTED, SUCCESS, SKIPPED);
 
     public static Status worst(List<Status> severalStatus) {
 
-        Status reducedStatus = severalStatus.stream()
+        List<Status> nonNullStatus = severalStatus.stream()
             .filter(Objects::nonNull)
+            .toList();
+
+        // skipped steps did not run, they must not weigh in the reduction
+        List<Status> executedStatus = nonNullStatus.stream().filter(s -> !s.equals(SKIPPED)).toList();
+        if (executedStatus.isEmpty()) {
+            return nonNullStatus.isEmpty() ? SUCCESS : SKIPPED;
+        }
+
+        Status reducedStatus = executedStatus.stream()
             .reduce(SUCCESS, EXECUTION_STATUS_STATUS_ORDERING::min);
 
         if(reducedStatus.equals(Status.NOT_EXECUTED)) {
-            List<Status> notExecutedStatus = severalStatus.stream().filter(s -> !s.equals(NOT_EXECUTED)).toList();
+            List<Status> notExecutedStatus = nonNullStatus.stream().filter(s -> !s.equals(NOT_EXECUTED)).toList();
             if(!notExecutedStatus.isEmpty()) {
                 return RUNNING;
             }

--- a/chutney/engine/src/main/java/fr/enedis/chutney/engine/domain/execution/strategies/IfStrategy.java
+++ b/chutney/engine/src/main/java/fr/enedis/chutney/engine/domain/execution/strategies/IfStrategy.java
@@ -7,7 +7,7 @@
 
 package fr.enedis.chutney.engine.domain.execution.strategies;
 
-import static fr.enedis.chutney.engine.domain.execution.report.Status.SUCCESS;
+import static fr.enedis.chutney.engine.domain.execution.report.Status.SKIPPED;
 
 import fr.enedis.chutney.engine.domain.execution.ScenarioExecution;
 import fr.enedis.chutney.engine.domain.execution.engine.evaluation.EvaluationException;
@@ -48,17 +48,17 @@ public class IfStrategy implements StepExecutionStrategy {
             Map<String, Object> context = new HashMap<>(scenarioContext);
             context.putAll(localContext);
             step.resolveName(context);
-            step.success();
+            step.skipped();
             skipAllSubSteps(step);
         }
-        return SUCCESS;
+        return SKIPPED;
     }
 
     private void skipAllSubSteps(Step step) {
         if (step.isParentStep()) {
             step.subSteps().forEach(subStep -> {
                 subStep.addInformation("Step skipped");
-                subStep.success();
+                subStep.skipped();
                 skipAllSubSteps(subStep);
             });
         }

--- a/chutney/engine/src/test/java/fr/enedis/chutney/engine/domain/execution/StatusTest.java
+++ b/chutney/engine/src/test/java/fr/enedis/chutney/engine/domain/execution/StatusTest.java
@@ -41,7 +41,14 @@ public class StatusTest {
             new Object[]{Status.WARN, new Status[]{Status.WARN, Status.NOT_EXECUTED}},
             new Object[]{Status.RUNNING, new Status[]{Status.NOT_EXECUTED, Status.SUCCESS}},
             new Object[]{Status.RUNNING, new Status[]{Status.NOT_EXECUTED, Status.RUNNING}},
-            new Object[]{Status.PAUSED, new Status[]{Status.PAUSED, Status.RUNNING}}
+            new Object[]{Status.PAUSED, new Status[]{Status.PAUSED, Status.RUNNING}},
+            new Object[]{Status.SKIPPED, new Status[]{Status.SKIPPED}},
+            new Object[]{Status.SKIPPED, new Status[]{Status.SKIPPED, Status.SKIPPED}},
+            new Object[]{Status.SUCCESS, new Status[]{Status.SKIPPED, Status.SUCCESS}},
+            new Object[]{Status.FAILURE, new Status[]{Status.SKIPPED, Status.FAILURE}},
+            new Object[]{Status.WARN, new Status[]{Status.SKIPPED, Status.WARN}},
+            new Object[]{Status.RUNNING, new Status[]{Status.SKIPPED, Status.NOT_EXECUTED, Status.SUCCESS}},
+            new Object[]{Status.RUNNING, new Status[]{Status.SKIPPED, Status.NOT_EXECUTED}}
         };
     }
 }

--- a/chutney/engine/src/test/java/fr/enedis/chutney/engine/domain/execution/engine/step/StepTest.java
+++ b/chutney/engine/src/test/java/fr/enedis/chutney/engine/domain/execution/engine/step/StepTest.java
@@ -106,6 +106,29 @@ public class StepTest {
     }
 
     @Test
+    public void should_not_fail_local_step_when_remote_report_is_skipped() {
+        // Given
+        StepDefinition fakeStepDefinition = new StepDefinition("fakeScenario", fakeTarget, "actionType", null, null, null, null, null);
+        Step step = new Step(dataEvaluator, fakeStepDefinition, new FakeStepExecutor(ActionExecutionResult.ok()), emptyList());
+
+        Map<String, Object> remoteResults = new HashMap<>();
+        remoteResults.put("remoteValue", "42");
+        StepExecutionReport remoteReport = new StepExecutionReportBuilder()
+            .setName("remote step")
+            .setStatus(Status.SKIPPED)
+            .setStepResults(remoteResults)
+            .createStepExecutionReport();
+
+        // When
+        step.updateContextFrom(remoteReport);
+
+        // Then
+        assertThat(step.status()).isNotEqualTo(Status.FAILURE);
+        assertThat(step.errors()).isEmpty();
+        assertThat(step.getStepOutputs()).containsEntry("remoteValue", "42");
+    }
+
+    @Test
     public void should_have_output_of_step_store_in_step_result() {
         // Given
         StepExecutor stepExecutor = new FakeStepExecutor(ActionExecutionResult.ok());

--- a/chutney/engine/src/test/java/fr/enedis/chutney/engine/domain/execution/strategies/IfStrategyTest.java
+++ b/chutney/engine/src/test/java/fr/enedis/chutney/engine/domain/execution/strategies/IfStrategyTest.java
@@ -8,6 +8,7 @@
 package fr.enedis.chutney.engine.domain.execution.strategies;
 
 import static fr.enedis.chutney.engine.domain.execution.ScenarioExecution.createScenarioExecution;
+import static fr.enedis.chutney.engine.domain.execution.report.Status.SKIPPED;
 import static fr.enedis.chutney.engine.domain.execution.report.Status.SUCCESS;
 import static java.util.Collections.emptyMap;
 import static java.util.Optional.empty;
@@ -46,9 +47,9 @@ public class IfStrategyTest {
 
     static Stream<Arguments> datasetForIf_strategy_nominal_cases() {
         return Stream.of(
-            of("Should not execute step if condition false", false, 0, SUCCESS, null),
+            of("Should not execute step if condition false", false, 0, SKIPPED, null),
             of("Should execute step if condition true", true, 1, SUCCESS, null, null),
-            of("Should not execute step if condition false Spel", "${ (1+1) == 3}", 0, SUCCESS, null),
+            of("Should not execute step if condition false Spel", "${ (1+1) == 3}", 0, SKIPPED, null),
             of("Should execute step if condition true Spel", "${ (1+1) == 2}", 1, SUCCESS, null)
         );
     }
@@ -77,7 +78,7 @@ public class IfStrategyTest {
         assertThat(status).isEqualTo(expectedStatus);
         verify(step, times(1)).addInformation("Execution condition [" + ifCondition + "] = " + (stepExecutionNumber == 1 ? "step executed" : "step skipped"));
         if (stepExecutionNumber == 0) {
-            verify(step).success();
+            verify(step).skipped();
         }
     }
 
@@ -136,9 +137,9 @@ public class IfStrategyTest {
 
     static Stream<Arguments> datasetForIf_strategy_on_parent_stepnominal_cases() {
         return Stream.of(
-            of("Should not execute step if condition false", false, 0, SUCCESS, null),
+            of("Should not execute step if condition false", false, 0, SKIPPED, null),
             of("Should execute step if condition true", true, 1, SUCCESS, null, null),
-            of("Should not execute step if condition false Spel", "${ (1+1) == 3}", 0, SUCCESS, null),
+            of("Should not execute step if condition false Spel", "${ (1+1) == 3}", 0, SKIPPED, null),
             of("Should execute step if condition true Spel", "${ (1+1) == 2}", 1, SUCCESS, null)
         );
     }
@@ -183,9 +184,9 @@ public class IfStrategyTest {
         assertThat(status).isEqualTo(expectedStatus);
         verify(step, times(1)).addInformation("Execution condition [" + ifCondition + "] = " + (stepExecutionNumber == 1 ? "step executed" : "step skipped"));
         if (stepExecutionNumber == 0) {
-            verify(step).success();
-            verify(step1).success();
-            verify(step2).success();
+            verify(step).skipped();
+            verify(step1).skipped();
+            verify(step2).skipped();
             verify(step1).addInformation(eq("Step skipped"));
             verify(step2).addInformation(eq("Step skipped"));
         }
@@ -245,7 +246,7 @@ public class IfStrategyTest {
             .execute(createScenarioExecution(null), ifStrategyStep, new ScenarioContextImpl(), new StepExecutionStrategies(Sets.newHashSet(DefaultStepExecutionStrategy.instance)));
 
         //Then
-        assertThat(status).isEqualTo(SUCCESS);
+        assertThat(status).isEqualTo(ifConditionEvaluation ? SUCCESS : SKIPPED);
         verify(ifStrategyStep, times(0)).execute(any(), any(), any());
         if (ifConditionEvaluation) {
             verify(ifStrategyStep).addInformation("Execution condition [" + ifCondition + "] = " + "step executed");
@@ -255,27 +256,78 @@ public class IfStrategyTest {
             });
         } else {
             verify(ifStrategyStep).addInformation("Execution condition [" + ifCondition + "] = " + "step skipped");
-            verify(ifStrategyStep).success();
+            verify(ifStrategyStep).skipped();
             List.of(parentSubStep, parentSubStep1, parentSubStep2, simpleSubStep).forEach(subStep -> {
                 verify(subStep, times(0)).execute(any(), any(), any());
                 verify(subStep).addInformation("Step skipped");
-                verify(subStep).success();
+                verify(subStep).skipped();
             });
         }
     }
 
     @Test
     public void should_resolve_name_from_context_with_strategy_if() {
-        // G
-        final TestEngine testEngine = new ExecutionConfiguration().embeddedTestEngine();
-        ExecutionRequestDto requestDto = Jsons.loadJsonFromClasspath("scenarios_examples/ifStrategy/if_strategy_step_with_name_resolver_from_context_put.json", ExecutionRequestDto.class);
+        StepExecutionReportDto result = executeScenario("if_strategy_step_with_name_resolver_from_context_put");
 
-        // W
-        StepExecutionReportDto result = testEngine.execute(requestDto);
-
-        // T
         assertThat(result).hasFieldOrPropertyWithValue("status", StatusDto.SUCCESS);
         assertThat(result.steps).hasSize(2);
         assertThat(result.steps.get(1).name).isEqualTo("Step 2 Parent : value");
+    }
+
+    @Test
+    public void should_skip_step_and_all_its_sub_steps_when_condition_is_false() {
+        StepExecutionReportDto result = executeScenario("if_strategy_false_skips_whole_subtree");
+
+        assertThat(result).hasFieldOrPropertyWithValue("status", StatusDto.SUCCESS);
+        assertThat(result.steps.get(0).status).isEqualTo(StatusDto.SUCCESS);
+        assertThat(result.steps.get(1).status).isEqualTo(StatusDto.SKIPPED);
+        assertThat(result.steps.get(1).steps.get(0).status).isEqualTo(StatusDto.SKIPPED);
+        assertThat(result.steps.get(1).steps.get(0).steps.get(0).status).isEqualTo(StatusDto.SKIPPED);
+        assertThat(result.steps.get(2).status).isEqualTo(StatusDto.SUCCESS);
+    }
+
+    @Test
+    public void should_skip_scenario_when_all_its_steps_are_skipped() {
+        StepExecutionReportDto result = executeScenario("if_strategy_false_on_every_step_skips_scenario");
+
+        assertThat(result).hasFieldOrPropertyWithValue("status", StatusDto.SKIPPED);
+        assertThat(result.steps.get(0).status).isEqualTo(StatusDto.SKIPPED);
+    }
+
+    @Test
+    public void should_evaluate_condition_from_context() {
+        StepExecutionReportDto result = executeScenario("if_strategy_condition_from_context");
+
+        assertThat(result).hasFieldOrPropertyWithValue("status", StatusDto.SUCCESS);
+        assertThat(result.steps.get(1).status).isEqualTo(StatusDto.SKIPPED);
+        assertThat(result.steps.get(2).status).isEqualTo(StatusDto.SUCCESS);
+    }
+
+    @Test
+    public void should_not_degrade_parent_step_using_another_strategy() {
+        StepExecutionReportDto result = executeScenario("if_strategy_false_inside_other_strategies");
+
+        assertThat(result).hasFieldOrPropertyWithValue("status", StatusDto.SUCCESS);
+        assertThat(result.steps.get(0).status).isEqualTo(StatusDto.SUCCESS);
+        assertThat(result.steps.get(0).steps.get(0).status).isEqualTo(StatusDto.SKIPPED);
+        assertThat(result.steps.get(1).status).isEqualTo(StatusDto.SUCCESS);
+        assertThat(result.steps.get(1).steps.get(0).status).isEqualTo(StatusDto.SKIPPED);
+        assertThat(result.steps.get(2).status).isEqualTo(StatusDto.SKIPPED);
+    }
+
+    @Test
+    public void should_skip_sub_steps_of_a_skipped_step_whatever_their_own_condition() {
+        StepExecutionReportDto result = executeScenario("if_strategy_true_containing_false");
+
+        assertThat(result).hasFieldOrPropertyWithValue("status", StatusDto.SUCCESS);
+        assertThat(result.steps.get(0).steps.get(0).status).isEqualTo(StatusDto.SKIPPED);
+        assertThat(result.steps.get(1).status).isEqualTo(StatusDto.SKIPPED);
+        assertThat(result.steps.get(1).steps.get(0).status).isEqualTo(StatusDto.SKIPPED);
+    }
+
+    private StepExecutionReportDto executeScenario(String scenarioFile) {
+        final TestEngine testEngine = new ExecutionConfiguration().embeddedTestEngine();
+        ExecutionRequestDto requestDto = Jsons.loadJsonFromClasspath("scenarios_examples/ifStrategy/" + scenarioFile + ".json", ExecutionRequestDto.class);
+        return testEngine.execute(requestDto);
     }
 }

--- a/chutney/engine/src/test/resources/scenarios_examples/ifStrategy/if_strategy_condition_from_context.json
+++ b/chutney/engine/src/test/resources/scenarios_examples/ifStrategy/if_strategy_condition_from_context.json
@@ -1,0 +1,39 @@
+{
+    "scenario": {
+        "name": "Scenario",
+        "steps": [
+            {
+                "name": "seed context",
+                "type": "context-put",
+                "inputs": {
+                    "entries": {
+                        "flag": "yes"
+                    }
+                }
+            },
+            {
+                "name": "skipped by context condition",
+                "strategy": {
+                    "type": "if",
+                    "parameters": {
+                        "condition": "${#flag == 'no'}"
+                    }
+                },
+                "type": "success"
+            },
+            {
+                "name": "executed by context condition",
+                "strategy": {
+                    "type": "if",
+                    "parameters": {
+                        "condition": "${#flag == 'yes'}"
+                    }
+                },
+                "type": "success"
+            }
+        ]
+    },
+    "environment": {
+        "name": "env"
+    }
+}

--- a/chutney/engine/src/test/resources/scenarios_examples/ifStrategy/if_strategy_false_inside_other_strategies.json
+++ b/chutney/engine/src/test/resources/scenarios_examples/ifStrategy/if_strategy_false_inside_other_strategies.json
@@ -1,0 +1,81 @@
+{
+    "scenario": {
+        "name": "Scenario",
+        "steps": [
+            {
+                "name": "retry parent",
+                "strategy": {
+                    "type": "retry-with-timeout",
+                    "parameters": {
+                        "timeOut": "1 s",
+                        "retryDelay": "100 ms"
+                    }
+                },
+                "steps": [
+                    {
+                        "name": "skipped inside retry",
+                        "strategy": {
+                            "type": "if",
+                            "parameters": {
+                                "condition": false
+                            }
+                        },
+                        "type": "success"
+                    },
+                    {
+                        "name": "executed inside retry",
+                        "type": "success"
+                    }
+                ]
+            },
+            {
+                "name": "soft assert parent",
+                "strategy": {
+                    "type": "soft-assert",
+                    "parameters": {}
+                },
+                "steps": [
+                    {
+                        "name": "skipped inside soft assert",
+                        "strategy": {
+                            "type": "if",
+                            "parameters": {
+                                "condition": false
+                            }
+                        },
+                        "type": "success"
+                    },
+                    {
+                        "name": "executed inside soft assert",
+                        "type": "success"
+                    }
+                ]
+            },
+            {
+                "name": "retry parent with only skipped steps",
+                "strategy": {
+                    "type": "retry-with-timeout",
+                    "parameters": {
+                        "timeOut": "1 s",
+                        "retryDelay": "100 ms"
+                    }
+                },
+                "steps": [
+                    {
+                        "name": "only step, skipped",
+                        "strategy": {
+                            "type": "if",
+                            "parameters": {
+                                "condition": false
+                            }
+                        },
+                        "type": "success"
+                    }
+                ]
+            }
+        ]
+    },
+    "environment": {
+        "name": "env"
+    }
+}

--- a/chutney/engine/src/test/resources/scenarios_examples/ifStrategy/if_strategy_false_on_every_step_skips_scenario.json
+++ b/chutney/engine/src/test/resources/scenarios_examples/ifStrategy/if_strategy_false_on_every_step_skips_scenario.json
@@ -1,0 +1,20 @@
+{
+    "scenario": {
+        "name": "Scenario",
+        "steps": [
+            {
+                "name": "only step, guarded by a false condition",
+                "strategy": {
+                    "type": "if",
+                    "parameters": {
+                        "condition": false
+                    }
+                },
+                "type": "success"
+            }
+        ]
+    },
+    "environment": {
+        "name": "env"
+    }
+}

--- a/chutney/engine/src/test/resources/scenarios_examples/ifStrategy/if_strategy_false_skips_whole_subtree.json
+++ b/chutney/engine/src/test/resources/scenarios_examples/ifStrategy/if_strategy_false_skips_whole_subtree.json
@@ -1,0 +1,38 @@
+{
+    "scenario": {
+        "name": "Scenario",
+        "steps": [
+            {
+                "name": "executed before",
+                "type": "success"
+            },
+            {
+                "name": "skipped parent",
+                "strategy": {
+                    "type": "if",
+                    "parameters": {
+                        "condition": false
+                    }
+                },
+                "steps": [
+                    {
+                        "name": "skipped child",
+                        "steps": [
+                            {
+                                "name": "skipped grandchild",
+                                "type": "success"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "executed after",
+                "type": "success"
+            }
+        ]
+    },
+    "environment": {
+        "name": "env"
+    }
+}

--- a/chutney/engine/src/test/resources/scenarios_examples/ifStrategy/if_strategy_true_containing_false.json
+++ b/chutney/engine/src/test/resources/scenarios_examples/ifStrategy/if_strategy_true_containing_false.json
@@ -1,0 +1,56 @@
+{
+    "scenario": {
+        "name": "Scenario",
+        "steps": [
+            {
+                "name": "outer executed",
+                "strategy": {
+                    "type": "if",
+                    "parameters": {
+                        "condition": true
+                    }
+                },
+                "steps": [
+                    {
+                        "name": "inner skipped",
+                        "strategy": {
+                            "type": "if",
+                            "parameters": {
+                                "condition": false
+                            }
+                        },
+                        "type": "success"
+                    },
+                    {
+                        "name": "inner executed",
+                        "type": "success"
+                    }
+                ]
+            },
+            {
+                "name": "outer skipped",
+                "strategy": {
+                    "type": "if",
+                    "parameters": {
+                        "condition": false
+                    }
+                },
+                "steps": [
+                    {
+                        "name": "inner condition never evaluated",
+                        "strategy": {
+                            "type": "if",
+                            "parameters": {
+                                "condition": true
+                            }
+                        },
+                        "type": "success"
+                    }
+                ]
+            }
+        ]
+    },
+    "environment": {
+        "name": "env"
+    }
+}

--- a/chutney/jira/src/main/java/fr/enedis/chutney/jira/domain/JiraXrayService.java
+++ b/chutney/jira/src/main/java/fr/enedis/chutney/jira/domain/JiraXrayService.java
@@ -79,7 +79,7 @@ public class JiraXrayService {
             report.startDate.atZone(ZoneId.systemDefault()).format(formatter),
             report.startDate.plusNanos(report.duration * 1000000).atZone(ZoneId.systemDefault()).format(formatter),
             getErrors(report).toString(),
-            report.status.equals("SUCCESS") ? PASS.value : FAIL.value
+            report.status.equals("SUCCESS") || report.status.equals("SKIPPED") ? PASS.value : FAIL.value
         );
 
         xrayTest.setEvidences(getEvidences(report.rootStep, ""));

--- a/chutney/server-core/src/main/java/fr/enedis/chutney/server/core/domain/execution/report/ServerReportStatus.java
+++ b/chutney/server-core/src/main/java/fr/enedis/chutney/server/core/domain/execution/report/ServerReportStatus.java
@@ -8,23 +8,32 @@
 package fr.enedis.chutney.server.core.domain.execution.report;
 
 import com.google.common.collect.Ordering;
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.StreamSupport;
 
 public enum ServerReportStatus {
-    SUCCESS, WARN, FAILURE, NOT_EXECUTED, STOPPED, PAUSED, RUNNING;
+    SUCCESS, WARN, FAILURE, NOT_EXECUTED, STOPPED, PAUSED, RUNNING, SKIPPED;
 
-    private static final Ordering<ServerReportStatus> EXECUTION_STATUS_STATUS_ORDERING = Ordering.explicit(PAUSED, RUNNING, STOPPED, FAILURE, WARN, NOT_EXECUTED, SUCCESS);
+    private static final Ordering<ServerReportStatus> EXECUTION_STATUS_STATUS_ORDERING = Ordering.explicit(PAUSED, RUNNING, STOPPED, FAILURE, WARN, NOT_EXECUTED, SUCCESS, SKIPPED);
 
     public static ServerReportStatus worst(Iterable<ServerReportStatus> severalStatus) {
-        return StreamSupport
+        List<ServerReportStatus> nonNullStatus = StreamSupport
             .stream(severalStatus.spliterator(), false)
             .filter(Objects::nonNull)
+            .toList();
+
+        List<ServerReportStatus> executedStatus = nonNullStatus.stream().filter(s -> !s.equals(SKIPPED)).toList();
+        if (executedStatus.isEmpty()) {
+            return nonNullStatus.isEmpty() ? SUCCESS : SKIPPED;
+        }
+
+        return executedStatus.stream()
             .reduce(SUCCESS, EXECUTION_STATUS_STATUS_ORDERING::min);
     }
 
     public boolean isFinal() {
-        return this.equals(FAILURE) || this.equals(SUCCESS) || this.equals(STOPPED);
+        return this.equals(FAILURE) || this.equals(SUCCESS) || this.equals(STOPPED) || this.equals(SKIPPED);
     }
 
     public interface HavingStatus {

--- a/chutney/server-core/src/main/java/fr/enedis/chutney/server/core/domain/scenario/campaign/CampaignExecution.java
+++ b/chutney/server-core/src/main/java/fr/enedis/chutney/server/core/domain/scenario/campaign/CampaignExecution.java
@@ -8,6 +8,7 @@
 package fr.enedis.chutney.server.core.domain.scenario.campaign;
 
 import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.RUNNING;
+import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.SKIPPED;
 import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.SUCCESS;
 import static fr.enedis.chutney.server.core.domain.tools.DatasetUtils.compareDataset;
 import static java.time.LocalDateTime.now;
@@ -248,7 +249,7 @@ public class CampaignExecution {
 
     public List<ScenarioExecutionCampaign> failedScenarioExecutions() {
         return scenarioExecutionReports().stream()
-            .filter(s -> !SUCCESS.equals(s.execution().status()))
+            .filter(s -> !SUCCESS.equals(s.execution().status()) && !SKIPPED.equals(s.execution().status()))
             .toList();
     }
 

--- a/chutney/server-core/src/test/java/fr/enedis/chutney/server/core/domain/execution/report/ServerReportStatusTest.java
+++ b/chutney/server-core/src/test/java/fr/enedis/chutney/server/core/domain/execution/report/ServerReportStatusTest.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2026 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.server.core.domain.execution.report;
+
+import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.FAILURE;
+import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.NOT_EXECUTED;
+import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.SKIPPED;
+import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.STOPPED;
+import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.SUCCESS;
+import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.WARN;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ServerReportStatusTest {
+
+    @Test
+    void should_be_success_when_no_status() {
+        assertThat(ServerReportStatus.worst(emptyList())).isEqualTo(SUCCESS);
+    }
+
+    @Test
+    void should_be_skipped_when_all_status_are_skipped() {
+        assertThat(ServerReportStatus.worst(List.of(SKIPPED))).isEqualTo(SKIPPED);
+        assertThat(ServerReportStatus.worst(List.of(SKIPPED, SKIPPED))).isEqualTo(SKIPPED);
+    }
+
+    static Stream<Arguments> skippedMixedCases() {
+        return Stream.of(
+            Arguments.of(SUCCESS, List.of(SKIPPED, SUCCESS)),
+            Arguments.of(FAILURE, List.of(SKIPPED, FAILURE)),
+            Arguments.of(WARN, List.of(SKIPPED, WARN)),
+            Arguments.of(STOPPED, List.of(SKIPPED, STOPPED)),
+            Arguments.of(NOT_EXECUTED, List.of(SKIPPED, NOT_EXECUTED))
+        );
+    }
+
+    @ParameterizedTest(name = "{1} -> {0}")
+    @MethodSource("skippedMixedCases")
+    void should_ignore_skipped_when_mixed_with_executed_status(ServerReportStatus expected, List<ServerReportStatus> input) {
+        assertThat(ServerReportStatus.worst(input)).isEqualTo(expected);
+    }
+
+    @Test
+    void should_consider_skipped_as_final() {
+        assertThat(SKIPPED.isFinal()).isTrue();
+    }
+}

--- a/chutney/server/src/main/java/fr/enedis/chutney/execution/api/report/surefire/SurefireScenarioExecutionReportBuilder.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/execution/api/report/surefire/SurefireScenarioExecutionReportBuilder.java
@@ -83,10 +83,10 @@ public class SurefireScenarioExecutionReportBuilder {
                     failure.setMessage(error);
                     testcase.getFailure().add(failure);
                 });
-            } else if (ServerReportStatus.NOT_EXECUTED == stepExecutionReport.status) {
+            } else if (ServerReportStatus.NOT_EXECUTED == stepExecutionReport.status || ServerReportStatus.SKIPPED == stepExecutionReport.status) {
                 skippedCounter.incrementAndGet();
                 Testsuite.Testcase.Skipped skipped = new Testsuite.Testcase.Skipped();
-                skipped.setMessage("Not executed");
+                skipped.setMessage(ServerReportStatus.SKIPPED == stepExecutionReport.status ? "Skipped" : "Not executed");
                 testcase.setSkipped(objectFactory.createTestsuiteTestcaseSkipped(skipped));
             }
             if (!stepExecutionReport.information.isEmpty()) {

--- a/chutney/server/src/main/java/fr/enedis/chutney/execution/domain/campaign/CampaignExecutionEngine.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/execution/domain/campaign/CampaignExecutionEngine.java
@@ -344,7 +344,9 @@ public class CampaignExecutionEngine {
     }
 
     private boolean isScenarioCompletelyExecuted(ServerReportStatus status) {
-        return ServerReportStatus.SUCCESS.equals(status) || ServerReportStatus.FAILURE.equals(status);
+        return ServerReportStatus.SUCCESS.equals(status)
+            || ServerReportStatus.FAILURE.equals(status)
+            || ServerReportStatus.SKIPPED.equals(status);
     }
 
     private ScenarioExecutionCampaign generateNotExecutedScenarioExecutionAndReport(Campaign campaign, TestCaseDataset testCaseDataset, CampaignExecution campaignExecution) {

--- a/chutney/server/src/test/java/fr/enedis/chutney/campaign/domain/CampaignExecutionTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/campaign/domain/CampaignExecutionTest.java
@@ -10,6 +10,7 @@ package fr.enedis.chutney.campaign.domain;
 import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.FAILURE;
 import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.NOT_EXECUTED;
 import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.RUNNING;
+import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.SKIPPED;
 import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.STOPPED;
 import static fr.enedis.chutney.server.core.domain.execution.report.ServerReportStatus.SUCCESS;
 import static java.util.Arrays.asList;
@@ -357,6 +358,21 @@ class CampaignExecutionTest {
             .isInstanceOf(ScenarioExecutionCampaign.class)
             .hasFieldOrPropertyWithValue("scenarioId", "2")
             .returns(Optional.of("dataset_2"), sec -> sec.execution().dataset().map(ds -> ds.id));
+    }
+
+    @Test
+    void should_not_replay_skipped_scenarios_as_failed_ones() {
+        CampaignExecution sut = CampaignExecutionReportBuilder.builder()
+            .userId("")
+            .build();
+        addScenarioExecutions(sut, "1", "", SUCCESS);
+        addScenarioExecutions(sut, "2", "", SKIPPED);
+        addScenarioExecutions(sut, "3", "", FAILURE);
+        addScenarioExecutions(sut, "4", "", STOPPED);
+
+        assertThat(sut.failedScenarioExecutions())
+            .extracting(ScenarioExecutionCampaign::scenarioId)
+            .containsExactlyInAnyOrder("3", "4");
     }
 
     @Test

--- a/chutney/server/src/test/java/fr/enedis/chutney/execution/api/report/surefire/SurefireScenarioExecutionReportBuilderTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/execution/api/report/surefire/SurefireScenarioExecutionReportBuilderTest.java
@@ -154,6 +154,50 @@ public class SurefireScenarioExecutionReportBuilderTest {
         assertThat(step2.getSystemOut()).isNull();
     }
 
+    @Test
+    public void create_with_skipped_step_should_not_count_it_as_a_passing_test() throws JacksonException {
+        // Given
+        StepExecutionReportCore rootStepReport =
+            stepReport("root step Title", 42L, ServerReportStatus.SUCCESS,
+                stepReport("step1", 23L, ServerReportStatus.SUCCESS),
+                stepReport("step2", 0L, ServerReportStatus.SKIPPED));
+
+        ScenarioExecutionReport report = new ScenarioExecutionReport(1L, "scenario name", "", "", null, rootStepReport);
+        ExecutionHistory.Execution execution = ImmutableExecutionHistory.Execution
+            .builder()
+            .executionId(report.executionId)
+            .duration(42L)
+            .status(ServerReportStatus.SUCCESS)
+            .time(LocalDateTime.now())
+            .report(objectMapper.writeValueAsString(report))
+            .testCaseTitle("fake")
+            .environment("")
+            .user("user")
+            .scenarioId("")
+            .build();
+
+        ScenarioExecutionCampaign scenarioExecutionCampaign = new ScenarioExecutionCampaign("123", "test3", execution.summary());
+        when(executionHistoryRepository.getExecution(scenarioExecutionCampaign.scenarioId(), report.executionId)).thenReturn(execution);
+
+        // When
+        Testsuite testsuite = sut.create(scenarioExecutionCampaign);
+
+        // Then
+        assertThat(testsuite.getTests()).isEqualTo("2");
+        assertThat(testsuite.getFailures()).isEqualTo("0");
+        assertThat(testsuite.getSkipped()).isEqualTo("1");
+
+        Testcase step1 = testsuite.getTestcase().getFirst();
+        assertThat(step1.getName()).isEqualTo("1 - step1");
+        assertThat(step1.getSkipped()).isNull();
+
+        Testcase step2 = testsuite.getTestcase().get(1);
+        assertThat(step2.getName()).isEqualTo("2 - step2");
+        assertThat(step2.getFailure()).hasSize(0);
+        assertThat(step2.getSkipped()).isNotNull();
+        assertThat(step2.getSkipped().getValue().message).isEqualTo("Skipped");
+    }
+
     private StepExecutionReportCore stepReport(String title, long duration, ServerReportStatus status, StepExecutionReportCore... subSteps) {
         List<String> infos = ServerReportStatus.SUCCESS == status ? singletonList("test info") : emptyList();
         List<String> errors = ServerReportStatus.FAILURE == status ? singletonList("test error") : emptyList();

--- a/chutney/ui/src/app/core/model/campaign/campaign-execution-report.model.ts
+++ b/chutney/ui/src/app/core/model/campaign/campaign-execution-report.model.ts
@@ -47,6 +47,7 @@ export class CampaignReport {
     stopped: number;
     notexecuted: number;
     pause: number;
+    skipped: number;
     total: number;
 
     constructor(report: CampaignExecutionReport) {
@@ -59,7 +60,8 @@ export class CampaignReport {
         this.failed = counts[3];
         this.stopped = counts[4];
         this.pause = counts[5];
-        this.total = this.passed + this.failed + this.stopped + this.notexecuted + this.running + this.pause;
+        this.skipped = counts[6];
+        this.total = this.passed + this.failed + this.stopped + this.notexecuted + this.running + this.pause + this.skipped;
     }
 
     private initCounts(report: CampaignExecutionReport): Array<number> {
@@ -69,8 +71,12 @@ export class CampaignReport {
         var stops = 0;
         var notExecuted = 0;
         var pauses = 0;
+        var skipped = 0;
         report.scenarioExecutionReports.forEach(r => {
             switch (r.status) {
+                case ExecutionStatus.SKIPPED:
+                    skipped++;
+                    break;
                 case ExecutionStatus.NOT_EXECUTED:
                     notExecuted++;
                     break;
@@ -91,7 +97,7 @@ export class CampaignReport {
                     break;
             }
         });
-        return [notExecuted, runnings, success, failures, stops, pauses];
+        return [notExecuted, runnings, success, failures, stops, pauses, skipped];
     }
 
     allPassed() {
@@ -120,6 +126,10 @@ export class CampaignReport {
 
     hasRunning() {
         return !!this.running;
+    }
+
+    hasSkipped() {
+        return !!this.skipped;
     }
 
     isRunning() {

--- a/chutney/ui/src/app/core/model/scenario/execution-status.ts
+++ b/chutney/ui/src/app/core/model/scenario/execution-status.ts
@@ -11,7 +11,8 @@ export enum ExecutionStatus {
     STOPPED = 'STOPPED',
     RUNNING = 'RUNNING',
     PAUSED = 'PAUSED',
-    NOT_EXECUTED = 'NOT_EXECUTED'
+    NOT_EXECUTED = 'NOT_EXECUTED',
+    SKIPPED = 'SKIPPED'
 }
 
 export namespace ExecutionStatus {

--- a/chutney/ui/src/app/modules/campaign/components/execution/detail/campaign-execution.component.html
+++ b/chutney/ui/src/app/modules/campaign/components/execution/detail/campaign-execution.component.html
@@ -32,6 +32,9 @@
                 @if (report.hasStopped()) {
                   {{ report.stopped }} {{ 'campaigns.execution.last.stop' | translate }},
                 }
+                @if (report.hasSkipped()) {
+                  {{ report.skipped }} {{ 'campaigns.execution.last.skipped' | translate }},
+                }
                 @if (report.hasNotExecuted()) {
                   {{ report.notexecuted }} {{ 'campaigns.execution.last.notexecuted' | translate }}
                 }

--- a/chutney/ui/src/app/modules/campaign/components/execution/detail/campaign-execution.component.ts
+++ b/chutney/ui/src/app/modules/campaign/components/execution/detail/campaign-execution.component.ts
@@ -209,6 +209,9 @@ export class CampaignExecutionComponent implements OnInit, OnDestroy, OnChanges 
         if (scenarioReportOutline.status === ExecutionStatus.NOT_EXECUTED) {
             return 'fa-regular fa-circle text-warning';
         }
+        if (scenarioReportOutline.status === ExecutionStatus.SKIPPED) {
+            return 'fa-solid fa-circle-minus text-secondary';
+        }
         return null;
     }
 

--- a/chutney/ui/src/app/modules/campaign/components/execution/history/list/campaign-executions.component.html
+++ b/chutney/ui/src/app/modules/campaign/components/execution/history/list/campaign-executions.component.html
@@ -172,6 +172,15 @@
                     </span>
                   </div>
                 }
+                @if (execution.hasSkipped()) {
+                  <div class="btn btn-sm position-relative"
+                    [title]="ExecutionStatus.toString(ExecutionStatus.SKIPPED) | translate">
+                    <span class="fa-solid fa-2xl fa-circle-minus text-secondary"></span>
+                    <span class="position-absolute top-0 start-75 translate-middle badge border border-secondary rounded-circle text-secondary">
+                      {{ execution.skipped }}
+                    </span>
+                  </div>
+                }
               </td>
               <td>
                 <ngb-highlight [result]="execution.report.executionEnvironment"

--- a/chutney/ui/src/app/modules/execution/components/resultExecutionSearchList/execution-search-list.component.html
+++ b/chutney/ui/src/app/modules/execution/components/resultExecutionSearchList/execution-search-list.component.html
@@ -125,6 +125,7 @@
                             'fa-circle-xmark icon-danger': execution.status === ExecutionStatus.FAILURE,
                             'fa-spinner fa-pulse icon-warning': execution.status === ExecutionStatus.RUNNING || execution.status === ExecutionStatus.PAUSED,
                             'fa-circle-exclamation icon-light': execution.status === ExecutionStatus.STOPPED,
+                            'fa-circle-minus text-secondary': execution.status === ExecutionStatus.SKIPPED,
                             'fa-regular fa-circle text-warning': execution.status === ExecutionStatus.NOT_EXECUTED}"
               [title]="ExecutionStatus.toString(execution.status) | translate"
             ></i>

--- a/chutney/ui/src/app/modules/scenarios/components/execution/history/list/scenario-executions.component.html
+++ b/chutney/ui/src/app/modules/scenarios/components/execution/history/list/scenario-executions.component.html
@@ -141,6 +141,7 @@
                                 'fa-circle-xmark icon-danger': execution.status === ExecutionStatus.FAILURE,
                                 'fa-spinner fa-pulse icon-warning': execution.status === ExecutionStatus.RUNNING || execution.status === ExecutionStatus.PAUSED,
                                 'fa-circle-exclamation icon-light': execution.status === ExecutionStatus.STOPPED,
+                                'fa-circle-minus text-secondary': execution.status === ExecutionStatus.SKIPPED,
                                 'fa-regular fa-circle text-warning': execution.status === ExecutionStatus.NOT_EXECUTED}"
                   [title]="ExecutionStatus.toString(execution.status) | translate"></i>
               </td>

--- a/chutney/ui/src/app/shared/components/execution-badge/execution-badge.component.html
+++ b/chutney/ui/src/app/shared/components/execution-badge/execution-badge.component.html
@@ -10,7 +10,8 @@
             'bg-danger':status == 'FAILURE',
             'badge-stopped': status == 'STOPPED',
             'badge-running': status == 'RUNNING' || status == 'PAUSED',
-            'badge-not-executed': status == 'NOT_EXECUTED'
+            'badge-not-executed': status == 'NOT_EXECUTED',
+            'badge-skipped': status == 'SKIPPED'
       }">
   {{ status_h }}
   @if (spin) {

--- a/chutney/ui/src/app/shared/components/execution-badge/execution-badge.component.scss
+++ b/chutney/ui/src/app/shared/components/execution-badge/execution-badge.component.scss
@@ -30,3 +30,8 @@
 .badge-not-executed {
     background-color: var(--bs-warning);
 }
+
+.badge-skipped {
+    font-style: italic;
+    background-color: var(--bs-gray-600);
+}

--- a/chutney/ui/src/app/shared/components/execution-badge/execution-badge.component.ts
+++ b/chutney/ui/src/app/shared/components/execution-badge/execution-badge.component.ts
@@ -43,6 +43,9 @@ export class ExecutionBadgeComponent implements OnChanges {
       case 'NOT_EXECUTED':
         this.status_h = 'NOT EXECUTED';
         break;
+      case 'SKIPPED':
+        this.status_h = 'SKIPPED';
+        break;
     }
   }
 

--- a/chutney/ui/src/app/shared/components/scenario-execution/execution.component.html
+++ b/chutney/ui/src/app/shared/components/scenario-execution/execution.component.html
@@ -254,12 +254,14 @@
             <span>
         <span class="mr-1">
           <i class="fa-solid fa-2xs fa-fw"
+             [title]="ExecutionStatus.toString(step.status) | translate"
              [ngClass]="{
                             'fa-circle': step.status == 'SUCCESS' || step.status == 'NOT_EXECUTED',
                             'step-header-success': step.status == 'SUCCESS',
                             'fa-circle-xmark step-header-failure': step.status == 'FAILURE',
                             'fa-circle-stop step-header-stopped': step.status == 'STOPPED',
                             'step-header-not-executed': step.status == 'NOT_EXECUTED',
+                            'fa-circle-minus step-header-skipped': step.status == 'SKIPPED',
                             'fa-spinner fa-spin step-header-running': step.status == 'RUNNING',
                             'fa-circle-pause step-header-running': step.status == 'PAUSED'
                         }">
@@ -287,10 +289,14 @@
                 'step-header-failure': step.status == 'FAILURE',
                 'step-header-stopped': step.status == 'STOPPED',
                 'step-header-not-executed': step.status == 'NOT_EXECUTED',
+                'step-header-skipped': step.status == 'SKIPPED',
                 'step-header-running': step.status == 'RUNNING' || step.status == 'PAUSED'}"
         >
             {{ step.name }}
-            @if (step.status != 'NOT_EXECUTED') {
+            @if (step.status == 'SKIPPED') {
+                <span class="badge bg-secondary ms-2 align-middle">{{ ExecutionStatus.toString(step.status) | translate }}</span>
+            }
+            @if (step.status != 'NOT_EXECUTED' && step.status != 'SKIPPED') {
                 <span placement="left" class="float-end small">
           <em>
             @if ((step.duration | duration); as d) {

--- a/chutney/ui/src/app/shared/components/scenario-execution/execution.component.scss
+++ b/chutney/ui/src/app/shared/components/scenario-execution/execution.component.scss
@@ -73,6 +73,9 @@
     .step-header-not-executed {
         color: var(--bs-gray-600);
     }
+    .step-header-skipped {
+        color: var(--bs-gray-600);
+    }
 
     .step-info {
         color: var(--bs-cyan);

--- a/chutney/ui/src/assets/i18n/en.json
+++ b/chutney/ui/src/assets/i18n/en.json
@@ -223,7 +223,8 @@
                 "ok": "OK",
                 "ko": "KO",
                 "stop": "Stopped",
-                "notexecuted": "Not executed"
+                "notexecuted": "Not executed",
+                "skipped": "Skipped"
             },
             "replay": "Replay failed scenarios",
             "replayWithJiraLink": {
@@ -491,7 +492,8 @@
             "running": "RUNNING",
             "paused": "PAUSE",
             "stopped": "STOP",
-            "not_executed": "NOT EXECUTED"
+            "not_executed": "NOT EXECUTED",
+            "skipped": "SKIPPED"
         },
         "time": {
             "in": "in",

--- a/chutney/ui/src/assets/i18n/fr.json
+++ b/chutney/ui/src/assets/i18n/fr.json
@@ -223,7 +223,8 @@
                 "ok": "OK",
                 "ko": "KO",
                 "stop": "Stoppés",
-                "notexecuted": "Non executés"
+                "notexecuted": "Non executés",
+                "skipped": "Ignorés"
             },
             "replay": "Rejouer les scénarios en échec",
             "replayWithJiraLink": {
@@ -491,7 +492,8 @@
             "running": "EN COURS",
             "paused": "PAUSE",
             "stopped": "STOP",
-            "not_executed": "NON EXÉCUTÉ"
+            "not_executed": "NON EXÉCUTÉ",
+            "skipped": "IGNORÉ"
         },
         "time": {
             "in": "en",

--- a/idea-plugin/src/main/kotlin/fr/enedis/chutney/idea/runner/JsonTestReportsParser.kt
+++ b/idea-plugin/src/main/kotlin/fr/enedis/chutney/idea/runner/JsonTestReportsParser.kt
@@ -171,7 +171,7 @@ class JsonTestReportsParser(
                 reportTestFailure(nodeId, parentNodeId, name, true, failureMessage, failureData)
             }
 
-            "NOT_EXECUTED" -> {
+            "NOT_EXECUTED", "SKIPPED" -> {
                 reportTestNotExecuted(nodeId, parentNodeId, name)
             }
 

--- a/kotlin-dsl/src/main/kotlin/fr/enedis/chutney/kotlin/execution/report/AnsiReportWriter.kt
+++ b/kotlin-dsl/src/main/kotlin/fr/enedis/chutney/kotlin/execution/report/AnsiReportWriter.kt
@@ -119,6 +119,7 @@ class AnsiReportWriter(private val withColor: Boolean = true) {
                 FAILURE -> RED.bright()
                 STOPPED -> YELLOW.bright()
                 NOT_EXECUTED -> MAGENTA.bright()
+                SKIPPED -> CYAN.bright()
                 else -> ""
             }.plus(s + RESET.color)
         } else s

--- a/kotlin-dsl/src/main/kotlin/fr/enedis/chutney/kotlin/junit/engine/execution/ChutneyScenarioExecutionContext.kt
+++ b/kotlin-dsl/src/main/kotlin/fr/enedis/chutney/kotlin/junit/engine/execution/ChutneyScenarioExecutionContext.kt
@@ -156,7 +156,7 @@ class ChutneyScenarioExecutionContext(
                 reportEntry = ReportEntry.from(
                     mapOf(
                         ChutneyJUnitReportingKeys.REPORT_JSON_STRING.value to JsonReportWriter.reportAsJson(ReportUtil.generateReportDto(rootStep)),
-                        ChutneyJUnitReportingKeys.REPORT_STATUS_SUCCESS.value to (executionStatus == Status.SUCCESS).toString()
+                        ChutneyJUnitReportingKeys.REPORT_STATUS_SUCCESS.value to (executionStatus == Status.SUCCESS || executionStatus == Status.SKIPPED).toString()
                     ))
             )
 

--- a/kotlin-dsl/src/main/kotlin/fr/enedis/chutney/kotlin/junit/engine/execution/ExecutionUtil.kt
+++ b/kotlin-dsl/src/main/kotlin/fr/enedis/chutney/kotlin/junit/engine/execution/ExecutionUtil.kt
@@ -61,7 +61,7 @@ fun testExecutionResultFromStatus(throwable: Throwable? = null, vararg status: S
     }
 
     val worst = Status.worst(status.asList())
-    return if (Status.SUCCESS == worst) {
+    return if (Status.SUCCESS == worst || Status.SKIPPED == worst) {
         TestExecutionResult.successful()
     } else {
         TestExecutionResult.failed(throwable)

--- a/kotlin-dsl/src/main/resources/chutney-report-website/chutney.js
+++ b/kotlin-dsl/src/main/resources/chutney-report-website/chutney.js
@@ -24,7 +24,7 @@ class Chutney {
 
     addReport(env, report) {
         const status = report.status;
-        const templateToUse = status === 'SUCCESS' ? this.reportSuccessTemplate : this.reportFailureTemplate;
+        const templateToUse = status === 'SUCCESS' || status === 'SKIPPED' ? this.reportSuccessTemplate : this.reportFailureTemplate;
         var templateClone = document.importNode(templateToUse.content, true);
         var div = templateClone.querySelector('div');
         div.textContent = report.name;

--- a/kotlin-dsl/src/test/kotlin/fr/enedis/chutney/kotlin/junit/engine/execution/ExecutionUtilTest.kt
+++ b/kotlin-dsl/src/test/kotlin/fr/enedis/chutney/kotlin/junit/engine/execution/ExecutionUtilTest.kt
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2026 Enedis
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package fr.enedis.chutney.kotlin.junit.engine.execution
+
+import fr.enedis.chutney.engine.domain.execution.report.Status
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.platform.engine.TestExecutionResult
+
+class ExecutionUtilTest {
+
+    @Test
+    fun `skipped status is not a failure`() {
+        val result = testExecutionResultFromStatus(null, Status.SKIPPED)
+
+        assertThat(result.status).isEqualTo(TestExecutionResult.Status.SUCCESSFUL)
+    }
+
+    @Test
+    fun `skipped alongside a success is not a failure`() {
+        val result = testExecutionResultFromStatus(null, Status.SKIPPED, Status.SUCCESS)
+
+        assertThat(result.status).isEqualTo(TestExecutionResult.Status.SUCCESSFUL)
+    }
+
+    @Test
+    fun `skipped alongside a failure is still a failure`() {
+        val result = testExecutionResultFromStatus(null, Status.SKIPPED, Status.FAILURE)
+
+        assertThat(result.status).isEqualTo(TestExecutionResult.Status.FAILED)
+    }
+}


### PR DESCRIPTION
#### Issue Number

NA

#### Describe the changes you've made

A step skipped by a false `if` condition was marked as SUCCESS, so a scenario where everything was skipped looked exactly like a scenario that really passed.

I added a SKIPPED status. IfStrategy now sets it on the skipped step and its substeps instead of calling success(). In Status.worst() and ServerReportStatus.worst() a SKIPPED entry is ignored when reducing, so it doesn't degrade siblings that did run, and it's only returned when everything is skipped.

The rest is making the new status behave like it did before wherever "not failed" was assumed: Xray still gets PASS, campaign replay doesn't treat a skipped scenario as failed, the surefire report counts it as skipped instead of a passing test, and the UI shows it in grey with a badge plus en/fr labels.

No database migration is needed: the STATUS column is a VARCHAR(32) mapped with `@Enumerated(EnumType.STRING)`, and nothing stores the status by ordinal.

#### Describe if there is any unusual behaviour of your code

A scenario where every step is skipped now reports SKIPPED instead of SUCCESS. That's the point of the change, but it does show up in campaign counts and reports, and it has a few knock-on effects worth calling out:

- `PurgeServiceImpl` protects the most recent SUCCESS execution from being purged. A scenario whose only non-failed runs were fully skipped no longer gets that protection. I left it that way because a skipped run isn't a green result worth keeping as a reference, but tell me if you'd rather SKIPPED counted there too.
- The JUnit engine (`ExecutionUtil.testExecutionResultFromStatus`, `ChutneyScenarioExecutionContext`) treats SKIPPED as not-a-failure, so a fully skipped `@ChutneyTest` scenario doesn't fail the build. I deliberately did not do the same to `Launcher.run(..., expected = SUCCESS)`: that one is an explicit assertion, and loosening it would mean nobody could assert that a scenario really ran and passed.
- `RetryWithTimeOutStrategy.executeAll` collapses every non-FAILURE status to SUCCESS, so under a retry the strategy's return value loses SKIPPED. The reported status is unaffected because reports are built from `Step.status()`, and I preferred not to touch that method in this PR. Happy to fix it here if you'd rather.

Like any new enum value, a report containing "SKIPPED" can't be read back by an older server, and an older delegated agent won't understand it (`StepExecutionReportMapper` does a bare `Status.valueOf`).

The idea-plugin change isn't covered by CI, since that module isn't in the root reactor.

#### Additional context

<img width="3412" height="1610" alt="image" src="https://github.com/user-attachments/assets/0c0e5842-1135-4e63-9924-218ec2958fe8" />

<img width="3390" height="1858" alt="image" src="https://github.com/user-attachments/assets/3c51ed9d-5231-4579-8dea-5185b353d43f" />

<img width="3418" height="1314" alt="image" src="https://github.com/user-attachments/assets/a29e41b6-b0c1-4902-88bb-87b94ade8e23" />

#### Test plan

Run a scenario with a step guarded by `"condition": false`. The step shows as SKIPPED and the scenario stays SUCCESS. If it's the only step, the scenario itself is SKIPPED (on main it's SUCCESS).

#### Checklist

- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [x] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
