### PR TITLE
fix(): keep givens/when/thens order in scenario json

### DIFF
--- a/chutney/server/src/main/java/fr/enedis/chutney/scenario/api/raw/mapper/GwtScenarioMapper.java
+++ b/chutney/server/src/main/java/fr/enedis/chutney/scenario/api/raw/mapper/GwtScenarioMapper.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import org.hjson.Stringify;
 import org.springframework.stereotype.Component;
 import tools.jackson.core.JacksonException;
+import tools.jackson.databind.MapperFeature;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import tools.jackson.databind.json.JsonMapper;
@@ -43,6 +44,9 @@ public class GwtScenarioMapper implements GwtScenarioMarshaller {
     // TODO - Refactor mappers scattered everywhere :)
     public static ObjectMapper mapper = JsonMapper.builder()
         .findAndAddModules()
+        // Jackson 3 sorts properties alphabetically by default. Scenario json is user visible and stored as text,
+        // so it must keep the declaration order of the domain classes, ie. givens, when, thens.
+        .disable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
         .changeDefaultPropertyInclusion(v -> v.withValueInclusion(JsonInclude.Include.NON_EMPTY))
         .changeDefaultVisibility(v -> v
             .withFieldVisibility(JsonAutoDetect.Visibility.ANY)

--- a/chutney/server/src/test/java/fr/enedis/chutney/scenario/api/raw/mapper/GwtScenarioMapperTest.java
+++ b/chutney/server/src/test/java/fr/enedis/chutney/scenario/api/raw/mapper/GwtScenarioMapperTest.java
@@ -11,8 +11,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import fr.enedis.chutney.execution.domain.GwtScenarioMarshaller;
 import fr.enedis.chutney.scenario.domain.gwt.GwtScenario;
+import fr.enedis.chutney.scenario.domain.gwt.GwtStep;
+import fr.enedis.chutney.scenario.domain.gwt.GwtStepImplementation;
+import fr.enedis.chutney.scenario.domain.gwt.Strategy;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import org.assertj.core.util.Files;
 import org.junit.jupiter.api.Test;
 
@@ -48,6 +53,45 @@ public class GwtScenarioMapperTest {
         assertThat(actualScenario.givens.getFirst().implementation.get().inputs).containsEntry("fake_param", "fake_value");
         assertThat(actualScenario.givens.getFirst().implementation.get().outputs).containsEntry("fake_output", "fake_output_value");
         assertThat(actualScenario.givens.getFirst().implementation.get().validations).containsEntry("fake_validation", "${true}");
+    }
+
+    @Test
+    public void should_serialize_scenario_keys_in_gwt_order_and_not_alphabetically() {
+        // Given a scenario whose GWT order differs from the alphabetical one
+        GwtScenario scenario = GwtScenario.builder()
+            .withGivens(List.of(GwtStep.builder().withDescription("a given").build()))
+            .withWhen(GwtStep.builder().withDescription("the when").build())
+            .withThens(List.of(GwtStep.builder().withDescription("a then").build()))
+            .build();
+
+        // When
+        String json = marshaller.serialize(scenario);
+
+        // Then: givens, when, thens and not the alphabetical givens, thens, when
+        assertThat(json.indexOf("\"givens\"")).isLessThan(json.indexOf("\"when\""));
+        assertThat(json.indexOf("\"when\"")).isLessThan(json.indexOf("\"thens\""));
+    }
+
+    @Test
+    public void should_serialize_step_keys_in_declaration_order_and_not_alphabetically() {
+        // Given a step declaring sub steps, an implementation and a strategy
+        GwtStep step = GwtStep.builder()
+            .withDescription("a given")
+            .withSubSteps(List.of(GwtStep.builder().withDescription("a sub step").build()))
+            .withImplementation(new GwtStepImplementation("success", "a target", Map.of("input", "value"), Map.of(), Map.of(), ""))
+            .withStrategy(new Strategy("retry-with-timeout", Map.of("timeOut", "1 s")))
+            .build();
+        GwtScenario scenario = GwtScenario.builder()
+            .withWhen(step)
+            .build();
+
+        // When
+        String json = marshaller.serialize(scenario);
+
+        // Then: description, subSteps, implementation, strategy and not the alphabetical description, implementation, strategy, subSteps
+        assertThat(json.indexOf("\"description\"")).isLessThan(json.indexOf("\"subSteps\""));
+        assertThat(json.indexOf("\"subSteps\"")).isLessThan(json.indexOf("\"implementation\""));
+        assertThat(json.indexOf("\"implementation\"")).isLessThan(json.indexOf("\"strategy\""));
     }
 
 }


### PR DESCRIPTION
<!--
  ~ SPDX-FileCopyrightText: 2017-2026 Enedis
  ~
  ~ SPDX-License-Identifier: Apache-2.0
  ~
  -->

#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made

<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [ ] All new and existing tests pass
- [ ] No git conflict
